### PR TITLE
Create initial single-page camera planner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atlas Caméras — Planification</title>
+    <link rel="stylesheet" href="src/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header" role="banner">
+        <div class="brand-block">
+          <div class="brand-icon" aria-hidden="true"></div>
+          <div>
+            <h1>Atlas Caméras</h1>
+            <p>Planification urbaine 2D</p>
+          </div>
+        </div>
+        <nav class="header-actions" aria-label="Actions principales">
+          <button class="ghost" type="button">Aide</button>
+          <button class="ghost" type="button">Exporter</button>
+        </nav>
+      </header>
+
+      <main class="app-main" role="main">
+        <aside class="panel panel-left" aria-label="Caméras">
+          <div class="panel-header">
+            <h2>Caméras</h2>
+            <button class="ghost" type="button" aria-label="Ajouter une caméra">
+              +
+            </button>
+          </div>
+          <div class="search-box">
+            <label class="sr-only" for="camera-search">Rechercher une caméra</label>
+            <input
+              id="camera-search"
+              type="search"
+              placeholder="Rechercher"
+              autocomplete="off"
+            />
+          </div>
+          <ul class="camera-list" role="list" aria-live="polite"></ul>
+          <div class="panel-footer">
+            <button class="ghost" type="button">Dupliquer</button>
+            <button class="ghost" type="button">Supprimer</button>
+          </div>
+        </aside>
+
+        <section class="map-stage" aria-label="Carte et couverture">
+          <div class="map-toolbar">
+            <button class="ghost" type="button">Fond</button>
+            <button class="ghost" type="button">Couches</button>
+          </div>
+          <div class="map-canvas" role="application" aria-label="Carte stylisée">
+            <canvas id="map-canvas" aria-hidden="true"></canvas>
+            <svg class="map-overlays" aria-hidden="true"></svg>
+            <div class="empty-state">
+              <h3>Commencez par placer une caméra</h3>
+              <p>Cliquez sur la carte pour positionner une caméra virtuelle.</p>
+            </div>
+          </div>
+        </section>
+
+        <aside class="panel panel-right" aria-label="Propriétés">
+          <div class="panel-header">
+            <h2>Propriétés</h2>
+          </div>
+          <form class="properties-form" aria-describedby="properties-help">
+            <fieldset>
+              <legend>Position</legend>
+              <label>
+                Latitude
+                <input name="lat" type="number" step="0.000001" />
+              </label>
+              <label>
+                Longitude
+                <input name="lon" type="number" step="0.000001" />
+              </label>
+              <label>
+                Hauteur (m)
+                <input name="z" type="number" min="0" step="0.1" />
+              </label>
+            </fieldset>
+
+            <fieldset>
+              <legend>Orientation</legend>
+              <label>
+                Azimut (°)
+                <input name="azimuth" type="number" min="0" max="360" step="1" />
+              </label>
+              <label>
+                Inclinaison (°)
+                <input name="tilt" type="number" min="-90" max="90" step="1" />
+              </label>
+              <label>
+                Champ (°)
+                <input name="fov" type="number" min="1" max="180" step="1" />
+              </label>
+              <label>
+                Portée (m)
+                <input name="range" type="number" min="0" step="1" />
+              </label>
+            </fieldset>
+
+            <fieldset>
+              <legend>Type</legend>
+              <label class="radio">
+                <input type="radio" name="type" value="cone" checked />
+                Cône
+              </label>
+              <label class="radio">
+                <input type="radio" name="type" value="panorama" />
+                360°
+              </label>
+            </fieldset>
+
+            <fieldset>
+              <legend>Options</legend>
+              <label class="checkbox">
+                <input type="checkbox" name="stickToBuilding" />
+                Coller au bâtiment
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" name="showZone" checked />
+                Afficher la zone
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" name="deadZones" />
+                Zones mortes
+              </label>
+            </fieldset>
+
+            <p id="properties-help" class="form-hint">
+              Ajustez les paramètres pour visualiser la couverture en temps réel.
+            </p>
+          </form>
+        </aside>
+      </main>
+
+      <footer class="action-bar" role="contentinfo">
+        <div class="left-group">
+          <button class="ghost" type="button">Annuler</button>
+          <button class="ghost" type="button">Refaire</button>
+        </div>
+        <div class="center-group">
+          <span class="badge">60 fps cible</span>
+        </div>
+        <div class="right-group">
+          <button class="primary" type="button">Partager le lien</button>
+        </div>
+      </footer>
+    </div>
+
+    <div class="tooltip" role="tooltip" hidden></div>
+
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,17 @@
+import { createStateStore } from './state.js';
+import { setupUI } from './ui.js';
+import { setupMapCanvas } from './map/canvas.js';
+import { registerKeyboardShortcuts } from './services/keyboard.js';
+import { setupTooltip } from './services/tooltip.js';
+import { setupUndoRedo } from './services/undoRedo.js';
+
+const store = createStateStore();
+
+const tooltip = setupTooltip(document.querySelector('.tooltip'));
+
+setupUI({ store, tooltip });
+setupMapCanvas({ store, tooltip });
+registerKeyboardShortcuts({ store });
+setupUndoRedo({ store });
+
+window.__atlasStore = store;

--- a/src/map/canvas.js
+++ b/src/map/canvas.js
@@ -1,0 +1,91 @@
+import { throttle } from '../utils/throttle.js';
+
+export function setupMapCanvas({ store, tooltip }) {
+  const canvas = document.getElementById('map-canvas');
+  const ctx = canvas.getContext('2d');
+
+  function resize() {
+    const { width, height } = canvas.getBoundingClientRect();
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = width * ratio;
+    canvas.height = height * ratio;
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    render();
+  }
+
+  const throttledResize = throttle(resize, 100);
+  window.addEventListener('resize', throttledResize, { passive: true });
+
+  canvas.addEventListener('click', (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const worldPosition = { lat: 48.8566 + y * 0.00001, lon: 2.3522 + x * 0.00001 };
+    const camera = store.addCamera({ ...worldPosition });
+    tooltip.show('Caméra ajoutée', { x: event.clientX, y: event.clientY });
+    setTimeout(() => tooltip.hide(), 1200);
+    store.selectCamera(camera.id);
+  });
+
+  store.subscribe(render);
+  resize();
+
+  return { destroy() {
+    window.removeEventListener('resize', throttledResize);
+  } };
+
+  function render() {
+    const { cameras } = store.getState();
+    const rect = canvas.getBoundingClientRect();
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.restore();
+
+    drawGrid(ctx, rect);
+
+    cameras.forEach((camera) => drawCamera(ctx, camera));
+  }
+}
+
+function drawGrid(ctx, rect) {
+  const spacing = 40;
+  ctx.save();
+  ctx.strokeStyle = 'rgba(15, 23, 42, 0.05)';
+  ctx.lineWidth = 1;
+  for (let x = spacing / 2; x < rect.width; x += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, rect.height);
+    ctx.stroke();
+  }
+  for (let y = spacing / 2; y < rect.height; y += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(rect.width, y);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawCamera(ctx, camera) {
+  const x = (camera.lon - 2.3522) * 100000;
+  const y = (camera.lat - 48.8566) * 100000;
+
+  ctx.save();
+  ctx.translate(x, y);
+
+  ctx.fillStyle = '#0a84ff';
+  ctx.beginPath();
+  ctx.arc(0, 0, 6, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(10, 132, 255, 0.4)';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, 0);
+  ctx.lineTo(Math.cos((camera.azimuth * Math.PI) / 180) * 24, Math.sin((camera.azimuth * Math.PI) / 180) * 24);
+  ctx.stroke();
+
+  ctx.restore();
+}

--- a/src/services/keyboard.js
+++ b/src/services/keyboard.js
@@ -1,0 +1,19 @@
+export function registerKeyboardShortcuts({ store }) {
+  window.addEventListener('keydown', (event) => {
+    const isMeta = event.metaKey || event.ctrlKey;
+    if (isMeta && event.key.toLowerCase() === 'z') {
+      event.preventDefault();
+      if (event.shiftKey) {
+        store.redo();
+      } else {
+        store.undo();
+      }
+    }
+    if (event.key === 'Delete') {
+      const id = store.getState().selectedCameraId;
+      if (id) {
+        store.removeCamera(id);
+      }
+    }
+  });
+}

--- a/src/services/tooltip.js
+++ b/src/services/tooltip.js
@@ -1,0 +1,24 @@
+export function setupTooltip(element) {
+  let hideTimeout;
+
+  function show(message, position) {
+    if (!element) return;
+    element.textContent = message;
+    element.style.left = `${position.x}px`;
+    element.style.top = `${position.y}px`;
+    element.hidden = false;
+    element.dataset.visible = 'true';
+    clearTimeout(hideTimeout);
+  }
+
+  function hide(delay = 0) {
+    if (!element) return;
+    clearTimeout(hideTimeout);
+    hideTimeout = setTimeout(() => {
+      element.dataset.visible = 'false';
+      element.hidden = true;
+    }, delay);
+  }
+
+  return { show, hide };
+}

--- a/src/services/undoRedo.js
+++ b/src/services/undoRedo.js
@@ -1,0 +1,17 @@
+import { deserializeState, serializeState } from '../utils/serialization.js';
+
+export function setupUndoRedo({ store }) {
+  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+  const encodedState = params.get('s');
+  if (encodedState) {
+    store.hydrate(deserializeState(encodedState));
+  }
+
+  store.subscribe(() => {
+    const serialized = serializeState(store.serialize());
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    params.set('s', serialized);
+    const nextHash = `#${params.toString()}`;
+    history.replaceState(null, '', `${window.location.pathname}${nextHash}`);
+  });
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,126 @@
+import { nanoid } from './utils/nanoid.js';
+
+const DEFAULT_CAMERA = {
+  lat: 48.8566,
+  lon: 2.3522,
+  z: 6,
+  azimuth: 45,
+  tilt: -10,
+  fov: 90,
+  range: 60,
+  type: 'cone',
+  stickToBuilding: false,
+  showZone: true,
+  deadZones: false,
+};
+
+export function createStateStore() {
+  let state = {
+    cameras: [],
+    selectedCameraId: null,
+    obstacles: [],
+    heatmap: null,
+    history: {
+      past: [],
+      future: [],
+      limit: 100,
+    },
+  };
+
+  const listeners = new Set();
+
+  function notify() {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  }
+
+  function pushHistory(nextState) {
+    state.history.past.push(structuredClone({ ...state, history: undefined }));
+    if (state.history.past.length > state.history.limit) {
+      state.history.past.shift();
+    }
+    state.history.future = [];
+    state = { ...state, ...nextState };
+    notify();
+  }
+
+  return {
+    getState() {
+      return state;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    addCamera(partial = {}) {
+      const camera = { id: nanoid(), ...DEFAULT_CAMERA, ...partial };
+      pushHistory({
+        cameras: [...state.cameras, camera],
+        selectedCameraId: camera.id,
+      });
+      return camera;
+    },
+    updateCamera(id, patch) {
+      const cameras = state.cameras.map((camera) =>
+        camera.id === id ? { ...camera, ...patch } : camera
+      );
+      pushHistory({ cameras });
+    },
+    removeCamera(id) {
+      const cameras = state.cameras.filter((camera) => camera.id !== id);
+      const selectedCameraId =
+        state.selectedCameraId === id ? cameras.at(-1)?.id ?? null : state.selectedCameraId;
+      pushHistory({ cameras, selectedCameraId });
+    },
+    selectCamera(id) {
+      state = { ...state, selectedCameraId: id };
+      notify();
+    },
+    setObstacles(obstacles) {
+      state = { ...state, obstacles };
+      notify();
+    },
+    setHeatmap(heatmap) {
+      state = { ...state, heatmap };
+      notify();
+    },
+    canUndo() {
+      return state.history.past.length > 0;
+    },
+    canRedo() {
+      return state.history.future.length > 0;
+    },
+    undo() {
+      if (!this.canUndo()) return;
+      const previous = state.history.past.pop();
+      state.history.future.unshift(structuredClone({ ...state, history: undefined }));
+      state = { ...state, ...previous };
+      notify();
+    },
+    redo() {
+      if (!this.canRedo()) return;
+      const next = state.history.future.shift();
+      state.history.past.push(structuredClone({ ...state, history: undefined }));
+      state = { ...state, ...next };
+      notify();
+    },
+    serialize() {
+      const { history, ...rest } = state;
+      return JSON.stringify(rest);
+    },
+    hydrate(serialized) {
+      try {
+        const parsed = JSON.parse(serialized);
+        state = {
+          ...state,
+          ...parsed,
+          history: { past: [], future: [], limit: state.history.limit },
+        };
+        notify();
+      } catch (error) {
+        console.error('Hydratation impossible', error);
+      }
+    },
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,405 @@
+:root {
+  color-scheme: only light;
+  --bg: #f5f6f7;
+  --surface: #ffffff;
+  --surface-alt: #f2f2f5;
+  --border: #d9dce3;
+  --border-strong: #bcc1cd;
+  --text: #1f2933;
+  --text-soft: #4c5663;
+  --accent: #0a84ff;
+  --accent-soft: rgba(10, 132, 255, 0.12);
+  --shadow: 0 12px 36px rgba(15, 23, 42, 0.08);
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  width: min(1400px, 100%);
+  height: 100vh;
+  background: var(--bg);
+  padding: 32px clamp(16px, 4vw, 40px);
+  gap: 24px;
+}
+
+.app-header {
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  padding: 20px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: var(--shadow);
+}
+
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.brand-icon {
+  width: 48px;
+  height: 48px;
+  background: radial-gradient(circle at 30% 30%, #0a84ff, #0056d6);
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.brand-block h1 {
+  font-size: 1.4rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.brand-block p {
+  margin: 4px 0 0;
+  color: var(--text-soft);
+  font-size: 0.95rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: 280px 1fr 320px;
+  gap: 24px;
+  height: 100%;
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow);
+  min-height: 0;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.panel-left .panel-footer {
+  margin-top: auto;
+  padding: 16px 24px 24px;
+  display: flex;
+  gap: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.search-box {
+  padding: 16px 24px;
+}
+
+.search-box input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  font-size: 0.95rem;
+}
+
+.camera-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px 12px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.camera-list li {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.camera-list .camera-name {
+  font-weight: 500;
+}
+
+.camera-list .camera-meta {
+  color: var(--text-soft);
+  font-size: 0.8rem;
+  justify-self: end;
+}
+
+.camera-list li:hover,
+.camera-list li[aria-selected='true'] {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.map-stage {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.map-toolbar {
+  display: flex;
+  gap: 12px;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.map-canvas {
+  position: relative;
+  flex: 1;
+  background: linear-gradient(180deg, #f9fafc 0%, #eef1f6 100%);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  overflow: hidden;
+}
+
+#map-canvas,
+.map-overlays {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.map-overlays {
+  pointer-events: none;
+}
+
+.empty-state {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 24px 32px;
+  border-radius: var(--radius-lg);
+  text-align: center;
+  backdrop-filter: blur(8px);
+}
+
+.panel-right .properties-form {
+  padding: 16px 24px 28px;
+  overflow-y: auto;
+}
+
+.properties-form fieldset {
+  border: none;
+  padding: 0;
+  margin: 0 0 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.properties-form legend {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.properties-form label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.properties-form input[type='number'],
+.properties-form input[type='search'] {
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  font-size: 0.95rem;
+}
+
+.radio,
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.form-hint {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.85rem;
+}
+
+.action-bar {
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  padding: 16px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: var(--shadow);
+}
+
+.action-bar .left-group,
+.action-bar .right-group {
+  display: flex;
+  gap: 12px;
+}
+
+.action-bar .center-group .badge {
+  background: var(--surface-alt);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 500;
+  color: var(--text-soft);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 10px 16px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(10, 132, 255, 0.3);
+  outline-offset: 2px;
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--text);
+}
+
+button.ghost:hover {
+  background: rgba(15, 23, 42, 0.05);
+}
+
+button.primary {
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 10px 20px rgba(10, 132, 255, 0.3);
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+}
+
+.tooltip {
+  position: fixed;
+  background: var(--text);
+  color: white;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  pointer-events: none;
+  transform: translate(-50%, -120%);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.tooltip[data-visible='true'] {
+  opacity: 1;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1280px) {
+  .app-main {
+    grid-template-columns: 260px 1fr 300px;
+  }
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    padding: 24px;
+  }
+
+  .app-main {
+    grid-template-columns: 240px 1fr;
+    grid-template-areas:
+      'panel-left map'
+      'panel-right map';
+  }
+
+  .panel-left {
+    grid-area: panel-left;
+  }
+
+  .map-stage {
+    grid-area: map;
+  }
+
+  .panel-right {
+    grid-area: panel-right;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-main {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .panel,
+  .map-stage {
+    border-radius: var(--radius-lg);
+  }
+
+  .panel-left,
+  .panel-right {
+    order: 2;
+  }
+
+  .map-stage {
+    order: 1;
+    min-height: 360px;
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,56 @@
+import { createCameraListItem } from './ui/cameraListItem.js';
+import { populateForm } from './ui/formBinding.js';
+
+export function setupUI({ store, tooltip }) {
+  const cameraList = document.querySelector('.camera-list');
+  const addButton = document.querySelector('.panel-header button');
+  const form = document.querySelector('.properties-form');
+  const undoButton = document.querySelector('.action-bar .left-group button:nth-child(1)');
+  const redoButton = document.querySelector('.action-bar .left-group button:nth-child(2)');
+
+  addButton.addEventListener('click', () => {
+    store.addCamera();
+  });
+
+  undoButton.addEventListener('click', () => store.undo());
+  redoButton.addEventListener('click', () => store.redo());
+
+  form.addEventListener('input', (event) => {
+    const field = event.target;
+    if (!field.name) return;
+    const cameraId = store.getState().selectedCameraId;
+    if (!cameraId) return;
+
+    const value = parseField(field);
+    store.updateCamera(cameraId, { [field.name]: value });
+  });
+
+  const handleState = (state) => {
+    renderCameraList(cameraList, state, store);
+    populateForm(form, state);
+    undoButton.disabled = !store.canUndo();
+    redoButton.disabled = !store.canRedo();
+  };
+
+  store.subscribe(handleState);
+  handleState(store.getState());
+}
+
+function parseField(field) {
+  if (field.type === 'checkbox') {
+    return field.checked;
+  }
+  if (field.type === 'number' || field.type === 'range') {
+    return field.valueAsNumber;
+  }
+  return field.value;
+}
+
+function renderCameraList(container, state, store) {
+  container.innerHTML = '';
+  for (const camera of state.cameras) {
+    const item = createCameraListItem(camera, state.selectedCameraId === camera.id);
+    item.addEventListener('click', () => store.selectCamera(camera.id));
+    container.appendChild(item);
+  }
+}

--- a/src/ui/cameraListItem.js
+++ b/src/ui/cameraListItem.js
@@ -1,0 +1,19 @@
+export function createCameraListItem(camera, selected) {
+  const li = document.createElement('li');
+  li.setAttribute('role', 'listitem');
+  li.dataset.id = camera.id;
+  if (selected) li.setAttribute('aria-selected', 'true');
+
+  const name = document.createElement('span');
+  name.className = 'camera-name';
+  name.textContent = camera.label ?? `Caméra ${camera.id.slice(-4)}`;
+
+  const meta = document.createElement('span');
+  meta.className = 'camera-meta';
+  meta.textContent = `${camera.type === 'cone' ? 'Cône' : '360°'} • ${Math.round(
+    camera.range
+  )} m`;
+
+  li.append(name, meta);
+  return li;
+}

--- a/src/ui/formBinding.js
+++ b/src/ui/formBinding.js
@@ -1,0 +1,21 @@
+export function populateForm(form, state) {
+  const camera = state.cameras.find((cam) => cam.id === state.selectedCameraId);
+  const controls = form.querySelectorAll('[name]');
+
+  for (const control of controls) {
+    if (!camera) {
+      control.value = '';
+      if (control.type === 'checkbox') control.checked = false;
+      control.disabled = true;
+      continue;
+    }
+
+    control.disabled = false;
+    const value = camera[control.name];
+    if (control.type === 'checkbox') {
+      control.checked = Boolean(value);
+    } else {
+      control.value = value ?? '';
+    }
+  }
+}

--- a/src/utils/nanoid.js
+++ b/src/utils/nanoid.js
@@ -1,0 +1,10 @@
+const alphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
+const alphabetLength = alphabet.length;
+
+export function nanoid(size = 10) {
+  let id = '';
+  crypto.getRandomValues(new Uint8Array(size)).forEach((value) => {
+    id += alphabet[value % alphabetLength];
+  });
+  return id;
+}

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -1,0 +1,12 @@
+export function serializeState(raw) {
+  return btoa(encodeURIComponent(raw));
+}
+
+export function deserializeState(encoded) {
+  try {
+    return decodeURIComponent(atob(encoded));
+  } catch (error) {
+    console.error('Impossible de décoder l\'état', error);
+    return '{}';
+  }
+}

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,0 +1,24 @@
+export function throttle(callback, delay) {
+  let last = 0;
+  let frame;
+
+  return (...args) => {
+    const now = performance.now();
+    const remaining = delay - (now - last);
+
+    if (remaining <= 0) {
+      if (frame) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
+      last = now;
+      callback.apply(null, args);
+    } else if (!frame) {
+      frame = requestAnimationFrame(() => {
+        last = performance.now();
+        frame = null;
+        callback.apply(null, args);
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- build an Apple-inspired single-page layout with header, camera list, map stage, and properties panel
- add light-only visual theme and responsive styling for panels, map canvas, and action bar
- scaffold state management, UI bindings, canvas grid rendering, keyboard shortcuts, tooltip, and shareable state encoding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7b2a5c908329821cf957c56f8d73