### PR TITLE
Add Leaflet Grenoble map and camera sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,16 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      crossorigin=""
+    />
+    <script
+      defer
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      crossorigin=""
+    ></script>
   </head>
   <body>
     <div class="app-shell">
@@ -58,8 +68,7 @@
             <button class="ghost" type="button">Couches</button>
           </div>
           <div class="map-canvas" role="application" aria-label="Carte stylisée">
-            <canvas id="map-canvas" aria-hidden="true"></canvas>
-            <svg class="map-overlays" aria-hidden="true"></svg>
+            <div id="map-view" aria-hidden="true"></div>
             <div class="empty-state">
               <h3>Commencez par placer une caméra</h3>
               <p>Cliquez sur la carte pour positionner une caméra virtuelle.</p>
@@ -92,19 +101,31 @@
               <legend>Orientation</legend>
               <label>
                 Azimut (°)
-                <input name="azimuth" type="number" min="0" max="360" step="1" />
+                <div class="slider-field">
+                  <input name="azimuth" type="range" min="0" max="360" step="1" />
+                  <output data-display-for="azimuth" aria-live="polite">45°</output>
+                </div>
               </label>
               <label>
                 Inclinaison (°)
-                <input name="tilt" type="number" min="-90" max="90" step="1" />
+                <div class="slider-field">
+                  <input name="tilt" type="range" min="-90" max="90" step="1" />
+                  <output data-display-for="tilt" aria-live="polite">-10°</output>
+                </div>
               </label>
               <label>
                 Champ (°)
-                <input name="fov" type="number" min="1" max="180" step="1" />
+                <div class="slider-field">
+                  <input name="fov" type="range" min="20" max="160" step="1" />
+                  <output data-display-for="fov" aria-live="polite">90°</output>
+                </div>
               </label>
               <label>
                 Portée (m)
-                <input name="range" type="number" min="0" step="1" />
+                <div class="slider-field">
+                  <input name="range" type="range" min="5" max="250" step="5" />
+                  <output data-display-for="range" aria-live="polite">60 m</output>
+                </div>
               </label>
             </fieldset>
 

--- a/src/map/canvas.js
+++ b/src/map/canvas.js
@@ -1,91 +1,179 @@
-import { throttle } from '../utils/throttle.js';
+const GRENOBLE_CENTER = [45.1885, 5.7245];
+const TILE_URL = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+const TILE_ATTRIBUTION =
+  "Données © OpenStreetMap contributeurs — Style © CARTO";
 
 export function setupMapCanvas({ store, tooltip }) {
-  const canvas = document.getElementById('map-canvas');
-  const ctx = canvas.getContext('2d');
+  const container = document.getElementById('map-view');
+  if (!container || typeof L === 'undefined') return;
 
-  function resize() {
-    const { width, height } = canvas.getBoundingClientRect();
-    const ratio = window.devicePixelRatio || 1;
-    canvas.width = width * ratio;
-    canvas.height = height * ratio;
-    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
-    render();
-  }
+  const map = L.map(container, {
+    zoomControl: true,
+    preferCanvas: true,
+  }).setView(GRENOBLE_CENTER, 14);
 
-  const throttledResize = throttle(resize, 100);
-  window.addEventListener('resize', throttledResize, { passive: true });
+  L.tileLayer(TILE_URL, {
+    maxZoom: 19,
+    attribution: TILE_ATTRIBUTION,
+  }).addTo(map);
 
-  canvas.addEventListener('click', (event) => {
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    const worldPosition = { lat: 48.8566 + y * 0.00001, lon: 2.3522 + x * 0.00001 };
-    const camera = store.addCamera({ ...worldPosition });
-    tooltip.show('Caméra ajoutée', { x: event.clientX, y: event.clientY });
-    setTimeout(() => tooltip.hide(), 1200);
+  const cameraLayer = L.layerGroup().addTo(map);
+  const emptyState = document.querySelector('.empty-state');
+
+  const resizeHandler = () => map.invalidateSize();
+  window.addEventListener('resize', resizeHandler, { passive: true });
+
+  map.on('click', (event) => {
+    const { lat, lng } = event.latlng;
+    const camera = store.addCamera({ lat, lon: lng });
+
+    const { clientX, clientY } = getClientPosition(event.originalEvent);
+    if (clientX != null && clientY != null) {
+      tooltip.show('Caméra ajoutée', { x: clientX, y: clientY });
+      tooltip.hide(1200);
+    }
+
     store.selectCamera(camera.id);
   });
 
   store.subscribe(render);
-  resize();
+  render();
 
-  return { destroy() {
-    window.removeEventListener('resize', throttledResize);
-  } };
+  return {
+    destroy() {
+      window.removeEventListener('resize', resizeHandler);
+      map.remove();
+    },
+  };
 
   function render() {
-    const { cameras } = store.getState();
-    const rect = canvas.getBoundingClientRect();
-    ctx.save();
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.restore();
+    const { cameras, selectedCameraId } = store.getState();
+    cameraLayer.clearLayers();
 
-    drawGrid(ctx, rect);
+    if (emptyState) {
+      emptyState.hidden = cameras.length > 0;
+    }
 
-    cameras.forEach((camera) => drawCamera(ctx, camera));
+    for (const camera of cameras) {
+      const isSelected = camera.id === selectedCameraId;
+      const layers = createCameraLayers(camera, isSelected);
+      for (const layer of layers) {
+        layer.addTo(cameraLayer);
+      }
+    }
+  }
+
+  function createCameraLayers(camera, isSelected) {
+    const layers = [];
+    if (!Number.isFinite(camera.lat) || !Number.isFinite(camera.lon)) {
+      return layers;
+    }
+
+    const latLng = [camera.lat, camera.lon];
+    const mainColor = isSelected ? '#2563eb' : '#0ea5e9';
+    const strokeColor = isSelected ? '#1d4ed8' : '#0284c7';
+
+    if (camera.showZone !== false && Number.isFinite(camera.range) && camera.range > 0) {
+      if (camera.type === 'panorama') {
+        const circle = L.circle(latLng, {
+          radius: camera.range,
+          color: strokeColor,
+          weight: isSelected ? 2 : 1,
+          opacity: 0.9,
+          fillOpacity: 0.12,
+          fillColor: mainColor,
+        });
+        attachSelection(circle, camera.id);
+        layers.push(circle);
+      } else {
+        const fov = Math.max(10, Math.min(camera.fov ?? 90, 160));
+        const halfFov = fov / 2;
+        const range = camera.range;
+        const left = destination(camera.lat, camera.lon, range, (camera.azimuth ?? 0) - halfFov);
+        const right = destination(camera.lat, camera.lon, range, (camera.azimuth ?? 0) + halfFov);
+        const beam = L.polygon([latLng, left, right], {
+          color: strokeColor,
+          weight: isSelected ? 2 : 1,
+          opacity: 0.9,
+          fillOpacity: 0.16,
+          fillColor: mainColor,
+          lineJoin: 'round',
+        });
+        attachSelection(beam, camera.id);
+        layers.push(beam);
+      }
+    }
+
+    if (camera.type !== 'panorama') {
+      const directionRange = Math.max(20, Math.min(camera.range || 40, 120));
+      const directionEnd = destination(camera.lat, camera.lon, directionRange, camera.azimuth ?? 0);
+      const direction = L.polyline([latLng, directionEnd], {
+        color: strokeColor,
+        weight: isSelected ? 3 : 2,
+        opacity: 0.8,
+      });
+      attachSelection(direction, camera.id);
+      layers.push(direction);
+    }
+
+    const marker = L.circleMarker(latLng, {
+      radius: isSelected ? 7 : 6,
+      color: strokeColor,
+      weight: 2,
+      fillColor: mainColor,
+      fillOpacity: 1,
+    });
+    attachSelection(marker, camera.id);
+    layers.push(marker);
+
+    if (isSelected) {
+      marker.bringToFront();
+    }
+
+    return layers;
+  }
+
+  function attachSelection(layer, cameraId) {
+    layer.on('click', (leafletEvent) => {
+      if (leafletEvent?.originalEvent) {
+        L.DomEvent.stop(leafletEvent.originalEvent);
+      }
+      L.DomEvent.stop(leafletEvent);
+      store.selectCamera(cameraId);
+    });
   }
 }
 
-function drawGrid(ctx, rect) {
-  const spacing = 40;
-  ctx.save();
-  ctx.strokeStyle = 'rgba(15, 23, 42, 0.05)';
-  ctx.lineWidth = 1;
-  for (let x = spacing / 2; x < rect.width; x += spacing) {
-    ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, rect.height);
-    ctx.stroke();
+function getClientPosition(event) {
+  if (!event) return { clientX: null, clientY: null };
+  if ('clientX' in event && 'clientY' in event) {
+    return { clientX: event.clientX, clientY: event.clientY };
   }
-  for (let y = spacing / 2; y < rect.height; y += spacing) {
-    ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(rect.width, y);
-    ctx.stroke();
+  if ('touches' in event && event.touches[0]) {
+    return { clientX: event.touches[0].clientX, clientY: event.touches[0].clientY };
   }
-  ctx.restore();
+  return { clientX: null, clientY: null };
 }
 
-function drawCamera(ctx, camera) {
-  const x = (camera.lon - 2.3522) * 100000;
-  const y = (camera.lat - 48.8566) * 100000;
+function destination(lat, lon, distance, bearingDeg) {
+  const radius = 6378137; // Terre (m)
+  const bearing = (bearingDeg * Math.PI) / 180;
+  const latRad = (lat * Math.PI) / 180;
+  const lonRad = (lon * Math.PI) / 180;
 
-  ctx.save();
-  ctx.translate(x, y);
+  const angularDistance = distance / radius;
 
-  ctx.fillStyle = '#0a84ff';
-  ctx.beginPath();
-  ctx.arc(0, 0, 6, 0, Math.PI * 2);
-  ctx.fill();
+  const destLat = Math.asin(
+    Math.sin(latRad) * Math.cos(angularDistance) +
+      Math.cos(latRad) * Math.sin(angularDistance) * Math.cos(bearing)
+  );
 
-  ctx.strokeStyle = 'rgba(10, 132, 255, 0.4)';
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.moveTo(0, 0);
-  ctx.lineTo(Math.cos((camera.azimuth * Math.PI) / 180) * 24, Math.sin((camera.azimuth * Math.PI) / 180) * 24);
-  ctx.stroke();
+  const destLon =
+    lonRad +
+    Math.atan2(
+      Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(latRad),
+      Math.cos(angularDistance) - Math.sin(latRad) * Math.sin(destLat)
+    );
 
-  ctx.restore();
+  return [(destLat * 180) / Math.PI, ((destLon * 180) / Math.PI + 540) % 360 - 180];
 }

--- a/src/state.js
+++ b/src/state.js
@@ -1,8 +1,8 @@
 import { nanoid } from './utils/nanoid.js';
 
 const DEFAULT_CAMERA = {
-  lat: 48.8566,
-  lon: 2.3522,
+  lat: 45.1885,
+  lon: 5.7245,
   z: 6,
   azimuth: 45,
   tilt: -10,

--- a/src/styles.css
+++ b/src/styles.css
@@ -190,21 +190,38 @@ body {
 .map-canvas {
   position: relative;
   flex: 1;
-  background: linear-gradient(180deg, #f9fafc 0%, #eef1f6 100%);
+  background: var(--surface);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   overflow: hidden;
 }
 
-#map-canvas,
-.map-overlays {
+#map-view {
   position: absolute;
   inset: 0;
-  width: 100%;
-  height: 100%;
 }
 
-.map-overlays {
-  pointer-events: none;
+.leaflet-container {
+  font-family: inherit;
+}
+
+.leaflet-control-zoom a {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  color: var(--text);
+}
+
+.leaflet-control-zoom a:hover {
+  background: rgba(248, 250, 252, 0.95);
+}
+
+.leaflet-control-attribution {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 999px;
+  padding: 4px 10px;
+  color: var(--text-soft);
+  font-size: 0.75rem;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
 }
 
 .empty-state {
@@ -217,6 +234,7 @@ body {
   border-radius: var(--radius-lg);
   text-align: center;
   backdrop-filter: blur(8px);
+  pointer-events: none;
 }
 
 .panel-right .properties-form {
@@ -250,6 +268,70 @@ body {
   border: 1px solid var(--border);
   background: var(--surface-alt);
   font-size: 0.95rem;
+}
+
+.properties-form input[type='range'] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(10, 132, 255, 0.2), rgba(10, 132, 255, 0.6));
+  outline: none;
+}
+
+.properties-form input[type='range']:disabled {
+  background: rgba(226, 232, 240, 0.6);
+  cursor: not-allowed;
+}
+
+.properties-form input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 2px 6px rgba(10, 132, 255, 0.35);
+  cursor: pointer;
+}
+
+.properties-form input[type='range']::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 2px 6px rgba(10, 132, 255, 0.35);
+  cursor: pointer;
+}
+
+.properties-form input[type='range']:disabled::-webkit-slider-thumb,
+.properties-form input[type='range']:disabled::-moz-range-thumb {
+  background: var(--border);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.slider-field {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.slider-field output {
+  background: var(--surface-alt);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-weight: 500;
+  min-width: 60px;
+  text-align: right;
+  color: var(--text-soft);
+}
+
+.slider-field input:disabled + output {
+  opacity: 0.5;
 }
 
 .radio,

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,5 @@
 import { createCameraListItem } from './ui/cameraListItem.js';
-import { populateForm } from './ui/formBinding.js';
+import { populateForm, updateControlDisplay } from './ui/formBinding.js';
 
 export function setupUI({ store, tooltip }) {
   const cameraList = document.querySelector('.camera-list');
@@ -18,8 +18,13 @@ export function setupUI({ store, tooltip }) {
   form.addEventListener('input', (event) => {
     const field = event.target;
     if (!field.name) return;
+    updateControlDisplay(form, field);
     const cameraId = store.getState().selectedCameraId;
     if (!cameraId) return;
+
+    if (field.type === 'radio' && !field.checked) {
+      return;
+    }
 
     const value = parseField(field);
     store.updateCamera(cameraId, { [field.name]: value });

--- a/src/ui/formBinding.js
+++ b/src/ui/formBinding.js
@@ -4,18 +4,73 @@ export function populateForm(form, state) {
 
   for (const control of controls) {
     if (!camera) {
-      control.value = '';
-      if (control.type === 'checkbox') control.checked = false;
       control.disabled = true;
+      if (control.type === 'checkbox' || control.type === 'radio') {
+        control.checked = false;
+      } else if (control.type === 'range') {
+        control.value = control.defaultValue ?? control.min ?? 0;
+      } else {
+        control.value = '';
+      }
       continue;
     }
 
     control.disabled = false;
     const value = camera[control.name];
+
     if (control.type === 'checkbox') {
       control.checked = Boolean(value);
+    } else if (control.type === 'radio') {
+      control.checked = camera[control.name] === control.value;
+    } else if (value !== undefined && value !== null) {
+      control.value = value;
     } else {
-      control.value = value ?? '';
+      control.value = '';
     }
   }
+
+  updateOutputs(form, camera);
+}
+
+export function updateControlDisplay(form, field) {
+  if (!field?.name) return;
+  if (field.type === 'radio' && !field.checked) return;
+  const output = form.querySelector(`output[data-display-for='${field.name}']`);
+  if (!output) return;
+
+  let value;
+  if (field.type === 'checkbox') {
+    value = field.checked;
+  } else if (field.type === 'number' || field.type === 'range') {
+    value = field.valueAsNumber;
+  } else {
+    value = field.value;
+  }
+
+  output.textContent = formatDisplay(field.name, value);
+}
+
+function updateOutputs(form, camera) {
+  const outputs = form.querySelectorAll('output[data-display-for]');
+  for (const output of outputs) {
+    const fieldName = output.dataset.displayFor;
+    const value = camera ? camera[fieldName] : null;
+    output.textContent = formatDisplay(fieldName, value);
+  }
+}
+
+function formatDisplay(name, value) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+
+  if (name === 'range') {
+    return `${Math.round(value)} m`;
+  }
+
+  if (name === 'azimuth' || name === 'tilt' || name === 'fov') {
+    return `${Math.round(value)}°`;
+  }
+
+  return `${value}`;
 }


### PR DESCRIPTION
## Summary
- integrate a Leaflet basemap focused on Grenoble with stylized tiles and camera overlays
- add range-slider controls with live readouts for azimuth, tilt, field of view, and range inputs
- refresh styling for the map view, attribution, and slider widgets to match the UI

## Testing
- No automated tests were run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68de7e0bd9808329b983d9bc1fe427ba