### PR TITLE
Retire les réglages d'options et d'inclinaison

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,13 +107,6 @@
                 </div>
               </label>
               <label>
-                Inclinaison (°)
-                <div class="slider-field">
-                  <input name="tilt" type="range" min="-90" max="90" step="1" />
-                  <output data-display-for="tilt" aria-live="polite">-10°</output>
-                </div>
-              </label>
-              <label>
                 Champ (°)
                 <div class="slider-field">
                   <input name="fov" type="range" min="20" max="160" step="1" />
@@ -138,22 +131,6 @@
               <label class="radio">
                 <input type="radio" name="type" value="panorama" />
                 360°
-              </label>
-            </fieldset>
-
-            <fieldset>
-              <legend>Options</legend>
-              <label class="checkbox">
-                <input type="checkbox" name="stickToBuilding" />
-                Coller au bâtiment
-              </label>
-              <label class="checkbox">
-                <input type="checkbox" name="showZone" checked />
-                Afficher la zone
-              </label>
-              <label class="checkbox">
-                <input type="checkbox" name="deadZones" />
-                Zones mortes
               </label>
             </fieldset>
 

--- a/src/state.js
+++ b/src/state.js
@@ -5,13 +5,9 @@ const DEFAULT_CAMERA = {
   lon: 5.7245,
   z: 6,
   azimuth: 45,
-  tilt: -10,
   fov: 90,
   range: 60,
   type: 'cone',
-  stickToBuilding: false,
-  showZone: true,
-  deadZones: false,
 };
 
 export function createStateStore() {

--- a/src/ui/formBinding.js
+++ b/src/ui/formBinding.js
@@ -68,7 +68,7 @@ function formatDisplay(name, value) {
     return `${Math.round(value)} m`;
   }
 
-  if (name === 'azimuth' || name === 'tilt' || name === 'fov') {
+  if (name === 'azimuth' || name === 'fov') {
     return `${Math.round(value)}°`;
   }
 


### PR DESCRIPTION
## Summary
- supprime le curseur d'inclinaison de la section Orientation
- retire le bloc Options et les propriétés associées du modèle de caméra
- ajuste le formatage de l'affichage des sorties pour refléter ces retraits

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de84b953988329b5b36d1c1336c7d5