### PR TITLE
Adjust layout spacing to remove scrolling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -38,12 +38,13 @@ body {
 
 .app-shell {
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   width: min(1400px, 100%);
   height: 100vh;
   background: var(--bg);
-  padding: 32px clamp(16px, 4vw, 40px);
-  gap: 24px;
+  padding: 24px clamp(12px, 3vw, 32px);
+  gap: 20px;
+  overflow: hidden;
 }
 
 .app-header {
@@ -90,8 +91,9 @@ body {
 .app-main {
   display: grid;
   grid-template-columns: 280px 1fr 320px;
-  gap: 24px;
+  gap: 20px;
   height: 100%;
+  min-height: 0;
 }
 
 .panel {
@@ -107,7 +109,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 24px 24px 16px;
+  padding: 20px 20px 12px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -119,14 +121,14 @@ body {
 
 .panel-left .panel-footer {
   margin-top: auto;
-  padding: 16px 24px 24px;
+  padding: 12px 20px 20px;
   display: flex;
-  gap: 12px;
+  gap: 10px;
   border-top: 1px solid var(--border);
 }
 
 .search-box {
-  padding: 16px 24px;
+  padding: 14px 20px;
 }
 
 .search-box input {
@@ -141,9 +143,9 @@ body {
 .camera-list {
   list-style: none;
   margin: 0;
-  padding: 0 12px 12px;
-  flex: 1;
-  overflow-y: auto;
+  padding: 0 10px 10px;
+  flex: none;
+  overflow: visible;
 }
 
 .camera-list li {
@@ -182,8 +184,8 @@ body {
 
 .map-toolbar {
   display: flex;
-  gap: 12px;
-  padding: 18px 24px;
+  gap: 10px;
+  padding: 16px 20px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -193,6 +195,7 @@ body {
   background: var(--surface);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
   overflow: hidden;
+  min-height: 0;
 }
 
 #map-view {
@@ -238,8 +241,8 @@ body {
 }
 
 .panel-right .properties-form {
-  padding: 16px 24px 28px;
-  overflow-y: auto;
+  padding: 14px 20px 24px;
+  overflow: visible;
 }
 
 .properties-form fieldset {


### PR DESCRIPTION
## Summary
- tighten shell padding and grid gaps so the layout fits within the viewport
- allow the main region and map canvas to shrink without introducing scrollbars
- show the full camera list and property form by removing internal scroll containers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8611140883298b7294f3bc127e5d