### PR TITLE
Optimize camera rendering with cached coverage results

### DIFF
--- a/src/map/canvas.js
+++ b/src/map/canvas.js
@@ -31,8 +31,12 @@ export function setupMapCanvas({ store, tooltip }) {
   window.addEventListener('resize', resizeHandler, { passive: true });
 
   let buildingSegments = [];
+  let buildingSegmentsVersion = 0;
+  let buildingSegmentsKey = '';
   let buildingCoverageBounds = null;
   let buildingRequestId = 0;
+  const coverageCache = new Map();
+  const cameraLayersCache = new Map();
 
   map.on('click', (event) => {
     const { lat, lng } = event.latlng;
@@ -70,26 +74,220 @@ export function setupMapCanvas({ store, tooltip }) {
       emptyState.hidden = cameras.length > 0;
     }
 
+    const activeIds = new Set();
     for (const camera of cameras) {
+      if (!camera || camera.id == null) continue;
       const isSelected = camera.id === selectedCameraId;
-      const layers = createCameraLayers(camera, isSelected);
-      for (const layer of layers) {
+      const appearance = getCameraAppearance(camera, isSelected);
+      const entry = ensureCameraLayers(camera, appearance);
+      if (!entry) continue;
+
+      activeIds.add(camera.id);
+      entry.update(camera, appearance);
+      for (const layer of entry.getLayers()) {
+        if (!layer) continue;
         layer.addTo(cameraLayer);
+        if (isSelected && typeof layer.bringToFront === 'function') {
+          layer.bringToFront();
+        }
       }
+    }
+
+    for (const cameraId of Array.from(cameraLayersCache.keys())) {
+      if (activeIds.has(cameraId)) continue;
+      const entry = cameraLayersCache.get(cameraId);
+      if (entry?.destroy) {
+        entry.destroy();
+      }
+      cameraLayersCache.delete(cameraId);
+    }
+
+    for (const cameraId of Array.from(coverageCache.keys())) {
+      if (activeIds.has(cameraId)) continue;
+      coverageCache.delete(cameraId);
     }
   }
 
-  function createCameraLayers(camera, isSelected) {
-    const layers = [];
-    if (!Number.isFinite(camera.lat) || !Number.isFinite(camera.lon)) {
-      return layers;
+  function ensureCameraLayers(camera, appearance) {
+    let entry = cameraLayersCache.get(camera.id);
+    if (!entry || entry.type !== camera.type) {
+      if (entry?.destroy) {
+        entry.destroy();
+      }
+      entry = createCameraLayerEntry(camera, appearance);
+      if (!entry) {
+        return null;
+      }
+      cameraLayersCache.set(camera.id, entry);
     }
+    return entry;
+  }
 
-    const latLng = [camera.lat, camera.lon];
+  function createCameraLayerEntry(camera, appearance) {
     const config = getCameraTypeConfig(camera.type);
     const isPanoramic = config.isPanoramic;
     const isPtz = camera.type === 'ptz';
-    const useInfrared = Boolean(camera.infrared);
+
+    if (isPtz) {
+      const ptz = createRotatingPtzLayer(camera, appearance);
+      if (!ptz) {
+        return null;
+      }
+      return {
+        type: camera.type,
+        ptz,
+        update(newCamera, newAppearance) {
+          ptz.updateCamera(newCamera);
+          ptz.updateAppearance(newAppearance);
+        },
+        getLayers() {
+          return [ptz.layer];
+        },
+        destroy() {
+          ptz.destroy();
+        },
+      };
+    }
+
+    const marker = L.circleMarker([camera.lat, camera.lon], {
+      radius: appearance.isSelected ? 7 : 6,
+      color: appearance.strokeColor,
+      weight: 2,
+      fillColor: appearance.mainColor,
+      fillOpacity: 1,
+    });
+    attachSelection(marker, camera.id);
+
+    let coveragePolygon = null;
+    let directionLine = null;
+    const layers = [];
+
+    return {
+      type: camera.type,
+      isPanoramic,
+      marker,
+      update(newCamera, newAppearance) {
+        layers.length = 0;
+
+        if (!Number.isFinite(newCamera.lat) || !Number.isFinite(newCamera.lon)) {
+          return;
+        }
+
+        const latLng = [newCamera.lat, newCamera.lon];
+        marker.setLatLng(latLng);
+        marker.setStyle({
+          radius: newAppearance.isSelected ? 7 : 6,
+          color: newAppearance.strokeColor,
+          weight: 2,
+          fillColor: newAppearance.mainColor,
+          fillOpacity: 1,
+        });
+
+        const hasZone =
+          newCamera.showZone !== false &&
+          Number.isFinite(newCamera.range) &&
+          newCamera.range > 0;
+
+        if (hasZone) {
+          if (isPanoramic) {
+            if (!coveragePolygon) {
+              coveragePolygon = L.polygon([], {
+                color: newAppearance.strokeColor,
+                weight: newAppearance.isSelected ? 2 : 1,
+                opacity: 0.9,
+                fillOpacity: 0.12,
+                fillColor: newAppearance.mainColor,
+                lineJoin: 'round',
+              });
+              attachSelection(coveragePolygon, newCamera.id);
+            }
+            const coverage = getPanoramaCoverage(newCamera);
+            if (coverage?.points) {
+              coveragePolygon.setLatLngs(coverage.points);
+            }
+            coveragePolygon.setStyle({
+              color: newAppearance.strokeColor,
+              weight: newAppearance.isSelected ? 2 : 1,
+              opacity: 0.9,
+              fillOpacity: 0.12,
+              fillColor: newAppearance.mainColor,
+            });
+            layers.push(coveragePolygon);
+          } else {
+            if (!coveragePolygon) {
+              coveragePolygon = L.polygon([], {
+                color: newAppearance.strokeColor,
+                weight: newAppearance.isSelected ? 2 : 1,
+                opacity: 0.9,
+                fillOpacity: 0.16,
+                fillColor: newAppearance.mainColor,
+                lineJoin: 'round',
+              });
+              attachSelection(coveragePolygon, newCamera.id);
+            }
+            const coverage = getDirectionalCoverage(newCamera);
+            if (coverage?.points) {
+              coveragePolygon.setLatLngs(coverage.points);
+            }
+            coveragePolygon.setStyle({
+              color: newAppearance.strokeColor,
+              weight: newAppearance.isSelected ? 2 : 1,
+              opacity: 0.9,
+              fillOpacity: 0.16,
+              fillColor: newAppearance.mainColor,
+            });
+            layers.push(coveragePolygon);
+
+            if (!directionLine) {
+              directionLine = L.polyline([], {
+                color: newAppearance.strokeColor,
+                weight: newAppearance.isSelected ? 3 : 2,
+                opacity: 0.8,
+              });
+              attachSelection(directionLine, newCamera.id);
+            }
+
+            let directionRange = newCamera.range || 40;
+            if (coverage?.centerDistance != null) {
+              directionRange = Math.min(directionRange, coverage.centerDistance);
+            }
+            const maxDirectionRange = 200;
+            directionRange = Math.max(5, Math.min(directionRange, maxDirectionRange));
+            const directionEnd = destination(
+              newCamera.lat,
+              newCamera.lon,
+              directionRange,
+              newCamera.azimuth ?? 0
+            );
+            directionLine.setLatLngs([latLng, directionEnd]);
+            directionLine.setStyle({
+              color: newAppearance.strokeColor,
+              weight: newAppearance.isSelected ? 3 : 2,
+              opacity: 0.8,
+            });
+            layers.push(directionLine);
+          }
+        }
+
+        layers.push(marker);
+      },
+      getLayers() {
+        return layers;
+      },
+      destroy() {
+        if (coveragePolygon) {
+          coveragePolygon.remove();
+        }
+        if (directionLine) {
+          directionLine.remove();
+        }
+        marker.remove();
+      },
+    };
+  }
+
+  function getCameraAppearance(camera, isSelected) {
+    const useInfrared = Boolean(camera?.infrared);
     const mainColor = useInfrared
       ? isSelected
         ? '#dc2626'
@@ -105,100 +303,79 @@ export function setupMapCanvas({ store, tooltip }) {
       ? '#1d4ed8'
       : '#0284c7';
 
-    if (isPtz) {
-      const ptzLayer = createRotatingPtzLayer(camera, {
-        isSelected,
-        mainColor,
-        strokeColor,
-      });
-      if (ptzLayer) {
-        layers.push(ptzLayer);
-      }
-      return layers;
-    }
-
-    let visionProfile = null;
-
-    if (camera.showZone !== false && Number.isFinite(camera.range) && camera.range > 0) {
-      if (isPanoramic) {
-        const coverage = computePanoramaCoverage(camera, buildingSegments);
-        if (coverage) {
-          visionProfile = coverage;
-          const circle = L.polygon(coverage.points, {
-            color: strokeColor,
-            weight: isSelected ? 2 : 1,
-            opacity: 0.9,
-            fillOpacity: 0.12,
-            fillColor: mainColor,
-            lineJoin: 'round',
-          });
-          attachSelection(circle, camera.id);
-          layers.push(circle);
-        }
-      } else {
-        const coverage = computeDirectionalCoverage(camera, buildingSegments);
-        if (coverage) {
-          visionProfile = coverage;
-          const beam = L.polygon(coverage.points, {
-            color: strokeColor,
-            weight: isSelected ? 2 : 1,
-            opacity: 0.9,
-            fillOpacity: 0.16,
-            fillColor: mainColor,
-            lineJoin: 'round',
-          });
-          attachSelection(beam, camera.id);
-          layers.push(beam);
-        }
-      }
-    }
-
-    if (!isPanoramic) {
-      let directionRange = camera.range || 40;
-      if (visionProfile?.centerDistance != null) {
-        directionRange = Math.min(directionRange, visionProfile.centerDistance);
-      }
-      const maxDirectionRange = 200;
-      directionRange = Math.max(5, Math.min(directionRange, maxDirectionRange));
-      const directionEnd = destination(camera.lat, camera.lon, directionRange, camera.azimuth ?? 0);
-      const direction = L.polyline([latLng, directionEnd], {
-        color: strokeColor,
-        weight: isSelected ? 3 : 2,
-        opacity: 0.8,
-      });
-      attachSelection(direction, camera.id);
-      layers.push(direction);
-    }
-
-    const marker = L.circleMarker(latLng, {
-      radius: isSelected ? 7 : 6,
-      color: strokeColor,
-      weight: 2,
-      fillColor: mainColor,
-      fillOpacity: 1,
-    });
-    attachSelection(marker, camera.id);
-    layers.push(marker);
-
-    if (isSelected) {
-      marker.bringToFront();
-    }
-
-    return layers;
+    return {
+      isSelected,
+      mainColor,
+      strokeColor,
+    };
   }
 
-  function createRotatingPtzLayer(camera, { isSelected, mainColor, strokeColor }) {
+  function getDirectionalCoverage(camera) {
+    if (!camera || camera.id == null) {
+      return computeDirectionalCoverage(camera, buildingSegments);
+    }
+    const entry = ensureCoverageEntry(camera.id);
+    const key = `${buildingSegmentsVersion}|${getDirectionalKey(camera)}`;
+    if (entry.directionalKey !== key) {
+      entry.directional = computeDirectionalCoverage(camera, buildingSegments);
+      entry.directionalKey = key;
+    }
+    return entry.directional;
+  }
+
+  function getPanoramaCoverage(camera) {
+    if (!camera || camera.id == null) {
+      return computePanoramaCoverage(camera, buildingSegments);
+    }
+    const entry = ensureCoverageEntry(camera.id);
+    const key = `${buildingSegmentsVersion}|${getPanoramaKey(camera)}`;
+    if (entry.panoramaKey !== key) {
+      entry.panorama = computePanoramaCoverage(camera, buildingSegments);
+      entry.panoramaKey = key;
+    }
+    return entry.panorama;
+  }
+
+  function ensureCoverageEntry(cameraId) {
+    let entry = coverageCache.get(cameraId);
+    if (!entry) {
+      entry = {
+        directional: null,
+        directionalKey: null,
+        panorama: null,
+        panoramaKey: null,
+      };
+      coverageCache.set(cameraId, entry);
+    }
+    return entry;
+  }
+
+  function getDirectionalKey(camera) {
+    const fov = camera?.fov ?? 90;
+    const azimuth = camera?.azimuth ?? 0;
+    const range = camera?.range ?? 0;
+    return [camera?.lat, camera?.lon, range, azimuth, fov].map(formatNumber).join('|');
+  }
+
+  function getPanoramaKey(camera) {
+    const range = camera?.range ?? 0;
+    return [camera?.lat, camera?.lon, range].map(formatNumber).join('|');
+  }
+
+  function createRotatingPtzLayer(camera, appearance) {
     if (!Number.isFinite(camera.lat) || !Number.isFinite(camera.lon)) {
       return null;
     }
 
-    const latLng = [camera.lat, camera.lon];
+    const cameraState = { ...camera };
+    const latLng = [cameraState.lat, cameraState.lon];
     const group = L.layerGroup();
+    let currentAppearance = { ...appearance };
     const marker = L.circleMarker(latLng, {
-      radius: isSelected ? 7 : 6,
-      color: strokeColor,
+      radius: currentAppearance.isSelected ? 7 : 6,
+      color: currentAppearance.strokeColor,
       weight: 2,
-      fillColor: mainColor,
+      fillColor: currentAppearance.mainColor,
       fillOpacity: 1,
     });
     attachSelection(marker, camera.id);
@@ -206,40 +383,58 @@ export function setupMapCanvas({ store, tooltip }) {
 
     let beam = null;
     let direction = null;
-    if (camera.showZone !== false && Number.isFinite(camera.range) && camera.range > 0) {
-      beam = L.polygon([latLng], {
-        color: strokeColor,
-        weight: isSelected ? 2 : 1,
-        opacity: 0.9,
-        fillOpacity: 0.18,
-        fillColor: mainColor,
-        lineJoin: 'round',
-      });
-      attachSelection(beam, camera.id);
-      group.addLayer(beam);
 
-      direction = L.polyline([latLng, latLng], {
-        color: strokeColor,
-        weight: isSelected ? 3 : 2,
-        opacity: 0.8,
-      });
-      attachSelection(direction, camera.id);
-      group.addLayer(direction);
-    }
+    const shouldShowZone = () =>
+      cameraState.showZone !== false && Number.isFinite(cameraState.range) && cameraState.range > 0;
 
-    if (isSelected) {
+    const ensureZoneLayers = () => {
+      if (!shouldShowZone()) {
+        if (beam) {
+          group.removeLayer(beam);
+          beam.remove();
+          beam = null;
+        }
+        if (direction) {
+          group.removeLayer(direction);
+          direction.remove();
+          direction = null;
+        }
+        return;
+      }
+
+      if (!beam) {
+        beam = L.polygon([latLng], {
+          color: currentAppearance.strokeColor,
+          weight: currentAppearance.isSelected ? 2 : 1,
+          opacity: 0.9,
+          fillOpacity: 0.18,
+          fillColor: currentAppearance.mainColor,
+          lineJoin: 'round',
+        });
+        attachSelection(beam, camera.id);
+        group.addLayer(beam);
+      }
+
+      if (!direction) {
+        direction = L.polyline([latLng, latLng], {
+          color: currentAppearance.strokeColor,
+          weight: currentAppearance.isSelected ? 3 : 2,
+          opacity: 0.8,
+        });
+        attachSelection(direction, camera.id);
+        group.addLayer(direction);
+      }
+    };
+
+    ensureZoneLayers();
+
+    if (currentAppearance.isSelected && typeof marker.bringToFront === 'function') {
       marker.bringToFront();
     }
 
-    if (!beam || !direction) {
-      return group;
-    }
-
     const rotationSpeed = 0.65; // degrees per frame
-    const fov = camera.fov ?? 90;
-    const range = Math.max(camera.range ?? 350, 5);
-    let angle = camera.azimuth ?? 0;
     let rafId = null;
+    let angle = cameraState.azimuth ?? 0;
 
     const requestFrame =
       typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
@@ -251,8 +446,14 @@ export function setupMapCanvas({ store, tooltip }) {
         : (id) => clearTimeout(id);
 
     const updateGeometry = () => {
+      if (!beam || !direction || !shouldShowZone()) {
+        return;
+      }
+
+      const fov = cameraState.fov ?? 90;
+      const range = Math.max(cameraState.range ?? 350, 5);
       const animatedCamera = {
-        ...camera,
+        ...cameraState,
         azimuth: angle,
         fov,
         range,
@@ -303,9 +504,6 @@ export function setupMapCanvas({ store, tooltip }) {
     const start = () => {
       stop();
       updateGeometry();
-      if (isSelected && typeof marker.bringToFront === 'function') {
-        marker.bringToFront();
-      }
       rafId = requestFrame(animate);
     };
 
@@ -319,10 +517,76 @@ export function setupMapCanvas({ store, tooltip }) {
     group.on('add', start);
     group.on('remove', stop);
 
-    // Start animation immediately when created
-    start();
+    if (beam && direction) {
+      start();
+    }
 
-    return group;
+    return {
+      layer: group,
+      updateCamera(updatedCamera) {
+        if (!Number.isFinite(updatedCamera.lat) || !Number.isFinite(updatedCamera.lon)) {
+          return;
+        }
+        cameraState.lat = updatedCamera.lat;
+        cameraState.lon = updatedCamera.lon;
+        cameraState.range = updatedCamera.range;
+        cameraState.fov = updatedCamera.fov;
+        cameraState.azimuth = updatedCamera.azimuth;
+        cameraState.showZone = updatedCamera.showZone;
+        latLng[0] = cameraState.lat;
+        latLng[1] = cameraState.lon;
+        marker.setLatLng(latLng);
+        ensureZoneLayers();
+        if (updatedCamera.azimuth != null) {
+          angle = updatedCamera.azimuth;
+        }
+        updateGeometry();
+        if (beam && direction && rafId == null && group._map) {
+          start();
+        }
+        if ((!beam || !direction) && rafId != null) {
+          stop();
+        }
+      },
+      updateAppearance({ isSelected: selected, mainColor: main, strokeColor: stroke }) {
+        currentAppearance = { isSelected: selected, mainColor: main, strokeColor: stroke };
+        marker.setStyle({
+          radius: selected ? 7 : 6,
+          color: stroke,
+          weight: 2,
+          fillColor: main,
+          fillOpacity: 1,
+        });
+        if (beam) {
+          beam.setStyle({
+            color: stroke,
+            weight: selected ? 2 : 1,
+            opacity: 0.9,
+            fillOpacity: 0.18,
+            fillColor: main,
+          });
+        }
+        if (direction) {
+          direction.setStyle({
+            color: stroke,
+            weight: selected ? 3 : 2,
+            opacity: 0.8,
+          });
+        }
+        if (selected && typeof marker.bringToFront === 'function') {
+          marker.bringToFront();
+        }
+      },
+      get layer() {
+        return group;
+      },
+      destroy() {
+        stop();
+        group.off('add', start);
+        group.off('remove', stop);
+        group.remove();
+      },
+    };
   }
 
   async function refreshBuildings() {
@@ -348,7 +612,19 @@ export function setupMapCanvas({ store, tooltip }) {
   }
 
   function updateBuildings(polygons) {
-    buildingSegments = buildSegments(polygons);
+    const segments = buildSegments(polygons);
+    const segmentsKey = createSegmentsKey(segments);
+    buildingSegments = segments;
+    if (segmentsKey !== buildingSegmentsKey) {
+      buildingSegmentsKey = segmentsKey;
+      buildingSegmentsVersion += 1;
+      for (const entry of coverageCache.values()) {
+        entry.directional = null;
+        entry.directionalKey = null;
+        entry.panorama = null;
+        entry.panoramaKey = null;
+      }
+    }
     buildingLayer.clearLayers();
     for (const polygon of polygons) {
       const layer = L.polygon(polygon, {
@@ -418,7 +694,7 @@ function computeDirectionalCoverage(camera, buildingSegments) {
   const halfFov = fov / 2;
   const azimuth = camera.azimuth ?? 0;
   const maxRange = camera.range;
-  const samples = Math.max(2, Math.ceil(fov / 6));
+  const samples = Math.max(2, Math.ceil(fov / 8));
   const startAngle = azimuth - halfFov;
   const points = [[camera.lat, camera.lon]];
 
@@ -439,7 +715,7 @@ function computePanoramaCoverage(camera, buildingSegments) {
   }
 
   const maxRange = camera.range;
-  const samples = 72;
+  const samples = 48;
   const points = [];
 
   for (let i = 0; i < samples; i += 1) {
@@ -535,4 +811,31 @@ function buildSegments(polygons) {
   }
 
   return segments;
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return 'null';
+  }
+  return Number(value).toFixed(6);
+}
+
+function createSegmentsKey(segments) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return '';
+  }
+  const parts = [];
+  for (const segment of segments) {
+    if (!Array.isArray(segment) || segment.length < 2) {
+      continue;
+    }
+    const [start, end] = segment;
+    if (!start || !end) {
+      continue;
+    }
+    parts.push(
+      `${formatNumber(start[0])},${formatNumber(start[1])},${formatNumber(end[0])},${formatNumber(end[1])}`
+    );
+  }
+  return parts.join('|');
 }


### PR DESCRIPTION
## Summary
- cache directional and panoramic coverage per camera and reuse existing Leaflet layers during render to avoid redundant work
- update PTZ rendering to reuse its animated layers while reacting to camera/appearance changes
- invalidate cached coverage when building segments change and reduce sampling density to lower computation cost

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dea433bfd48329a8686d9b92330b36