### PR TITLE
Improve panels responsiveness and scrolling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,20 +31,21 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
+  min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: stretch;
+  align-items: flex-start;
 }
 
 .app-shell {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   width: min(1400px, 100%);
-  height: 100vh;
+  min-height: 100vh;
   background: var(--bg);
   padding: 24px clamp(12px, 3vw, 32px);
   gap: 20px;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .app-header {
@@ -103,6 +104,7 @@ body {
   flex-direction: column;
   box-shadow: var(--shadow);
   min-height: 0;
+  overflow: hidden;
 }
 
 .panel-header {
@@ -143,9 +145,9 @@ body {
 .camera-list {
   list-style: none;
   margin: 0;
-  padding: 0 10px 10px;
-  flex: none;
-  overflow: visible;
+  padding: 0 12px 16px;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .camera-list li {
@@ -235,13 +237,17 @@ body {
 
 .panel-right .properties-form {
   padding: 14px 20px 24px;
-  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .properties-form fieldset {
   border: none;
   padding: 0;
-  margin: 0 0 20px;
+  margin: 0;
   display: grid;
   gap: 12px;
 }
@@ -332,6 +338,10 @@ body {
 
 .camera-type-fieldset {
   gap: 16px;
+}
+
+.type-summary {
+  flex-wrap: wrap;
 }
 
 .camera-type-options {


### PR DESCRIPTION
## Summary
- allow the overall shell to grow and scroll so content no longer overflows the viewport
- enable scrolling within the camera list and properties panel for large amounts of content
- wrap long metadata strings so camera profile text stays within the layout

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deb541e93c8329aa71621378031a06