### PR TITLE
Fix IR checkbox alignment and add scrollable camera panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,9 @@
               autocomplete="off"
             />
           </div>
-          <ul class="camera-list" role="list" aria-live="polite"></ul>
+          <div class="camera-list-scroll" role="presentation">
+            <ul class="camera-list" role="list" aria-live="polite"></ul>
+          </div>
           <div class="panel-footer">
             <button
               class="ghost ghost--danger"

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,12 +142,19 @@ body {
   font-size: 0.95rem;
 }
 
+.camera-list-scroll {
+  flex: 1;
+  padding: 0 12px 16px;
+  overflow-y: auto;
+}
+
 .camera-list {
   list-style: none;
   margin: 0;
-  padding: 0 12px 16px;
-  flex: 1;
-  overflow-y: auto;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .camera-list li {
@@ -261,6 +268,16 @@ body {
   display: grid;
   gap: 6px;
   font-size: 0.95rem;
+}
+
+.properties-form label.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.properties-form label.checkbox input[type='checkbox'] {
+  margin: 0;
 }
 
 .properties-form input[type='number'],


### PR DESCRIPTION
## Summary
- align the vision infrarouge checkbox with its label inside the properties panel
- wrap the camera list in a dedicated scroll container so adding cameras no longer stretches the layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dfb8c2189483299c25a49f4ef3eedb