### PR TITLE
Add interactive route planning panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,33 +38,80 @@
       </header>
 
       <main class="app-main" role="main">
-        <aside class="panel panel-left" aria-label="Caméras">
-          <div class="panel-header">
-            <h2>Caméras</h2>
-            <button class="ghost" type="button" aria-label="Ajouter une caméra">
-              +
-            </button>
-          </div>
-          <div class="search-box">
-            <label class="sr-only" for="camera-search">Rechercher une caméra</label>
-            <input
-              id="camera-search"
-              type="search"
-              placeholder="Rechercher"
-              autocomplete="off"
-            />
-          </div>
-          <ul class="camera-list" role="list" aria-live="polite"></ul>
-          <div class="panel-footer">
-            <button
-              class="ghost ghost--danger"
-              type="button"
-              data-action="delete-camera"
-            >
-              Supprimer
-            </button>
-          </div>
-        </aside>
+        <div class="sidebar-column">
+          <aside class="panel route-panel" aria-label="Itinéraire">
+            <div class="panel-header">
+              <h2>Itinéraire</h2>
+            </div>
+            <div class="route-panel-body">
+              <p class="route-panel-status" data-role="route-status" aria-live="polite">
+                Sélectionnez un point de départ et d’arrivée.
+              </p>
+              <div class="route-points" role="group" aria-label="Points de l’itinéraire">
+                <button
+                  type="button"
+                  class="route-point-button route-point-button--start"
+                  data-route-point="start"
+                  aria-pressed="false"
+                >
+                  <span class="route-point-title">Point A</span>
+                  <span class="route-point-meta" data-role="point-start-meta">Cliquez sur la carte</span>
+                </button>
+                <div class="route-points-connector" aria-hidden="true"></div>
+                <button
+                  type="button"
+                  class="route-point-button route-point-button--end"
+                  data-route-point="end"
+                  aria-pressed="false"
+                >
+                  <span class="route-point-title">Point B</span>
+                  <span class="route-point-meta" data-role="point-end-meta">Cliquez sur la carte</span>
+                </button>
+              </div>
+              <div class="route-panel-summary" aria-live="polite">
+                <span>Trajet :</span>
+                <strong data-role="route-summary">—</strong>
+              </div>
+              <button
+                type="button"
+                class="ghost route-reset"
+                data-action="clear-route"
+                aria-disabled="true"
+                disabled
+              >
+                Réinitialiser
+              </button>
+            </div>
+          </aside>
+
+          <aside class="panel panel-left" aria-label="Caméras">
+            <div class="panel-header">
+              <h2>Caméras</h2>
+              <button class="ghost" type="button" aria-label="Ajouter une caméra">
+                +
+              </button>
+            </div>
+            <div class="search-box">
+              <label class="sr-only" for="camera-search">Rechercher une caméra</label>
+              <input
+                id="camera-search"
+                type="search"
+                placeholder="Rechercher"
+                autocomplete="off"
+              />
+            </div>
+            <ul class="camera-list" role="list" aria-live="polite"></ul>
+            <div class="panel-footer">
+              <button
+                class="ghost ghost--danger"
+                type="button"
+                data-action="delete-camera"
+              >
+                Supprimer
+              </button>
+            </div>
+          </aside>
+        </div>
 
         <section class="map-stage" aria-label="Carte et couverture">
           <div class="map-canvas" role="application" aria-label="Carte stylisée">

--- a/src/services/routing.js
+++ b/src/services/routing.js
@@ -1,0 +1,36 @@
+const OSRM_BASE_URL = 'https://router.project-osrm.org/route/v1/driving/';
+
+function buildRouteUrl(start, end) {
+  const startCoords = `${start.lon},${start.lat}`;
+  const endCoords = `${end.lon},${end.lat}`;
+  const params = new URLSearchParams({ overview: 'full', geometries: 'geojson' });
+  return `${OSRM_BASE_URL}${startCoords};${endCoords}?${params.toString()}`;
+}
+
+export async function fetchRouteBetween(start, end) {
+  if (!start || !end) {
+    throw new Error('Points de départ et d’arrivée requis.');
+  }
+
+  const url = buildRouteUrl(start, end);
+  const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
+  if (!response.ok) {
+    throw new Error('Service de calcul d’itinéraire indisponible.');
+  }
+
+  const data = await response.json();
+  if (data.code !== 'Ok' || !Array.isArray(data.routes) || data.routes.length === 0) {
+    throw new Error('Aucun itinéraire trouvé pour ces points.');
+  }
+
+  const [route] = data.routes;
+  const coordinates = Array.isArray(route.geometry?.coordinates)
+    ? route.geometry.coordinates.map(([lon, lat]) => ({ lat, lon }))
+    : [];
+
+  return {
+    coordinates,
+    distance: route.distance ?? null,
+    duration: route.duration ?? null,
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -97,6 +97,17 @@ body {
   min-height: 0;
 }
 
+.sidebar-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 0;
+}
+
+.sidebar-column .panel {
+  min-height: 0;
+}
+
 .panel {
   background: var(--surface);
   border-radius: var(--radius-lg);
@@ -105,6 +116,180 @@ body {
   box-shadow: var(--shadow);
   min-height: 0;
   overflow: hidden;
+}
+
+.route-panel {
+  border-radius: var(--radius-md);
+}
+
+.route-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 20px 20px;
+}
+
+.route-panel-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-soft);
+}
+
+.route-points {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 12px;
+  align-items: center;
+}
+
+.route-point-button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  padding: 14px 16px 14px 48px;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    background 0.2s ease;
+}
+
+.route-point-button::before {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  background: var(--surface);
+  left: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.route-point-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.route-point-button.is-active {
+  border-color: var(--accent);
+  background: rgba(10, 132, 255, 0.08);
+  box-shadow: 0 14px 26px rgba(10, 132, 255, 0.18);
+}
+
+.route-point-button.is-active::before {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.route-point-button.is-defined::before {
+  background: currentColor;
+}
+
+.route-point-button--start {
+  color: #047857;
+}
+
+.route-point-button--start::before {
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+.route-point-button--start.is-defined {
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
+.route-point-button--start.is-active::before {
+  background: #10b981;
+  border-color: rgba(16, 185, 129, 0.8);
+}
+
+.route-point-button--end {
+  color: #b91c1c;
+}
+
+.route-point-button--end::before {
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.route-point-button--end.is-defined {
+  border-color: rgba(239, 68, 68, 0.6);
+}
+
+.route-point-button--end.is-active::before {
+  background: #ef4444;
+  border-color: rgba(239, 68, 68, 0.8);
+}
+
+.route-point-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.route-point-meta {
+  font-size: 0.85rem;
+  color: var(--text-soft);
+}
+
+.route-points-connector {
+  width: 36px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(16, 185, 129, 0.6), rgba(239, 68, 68, 0.6));
+}
+
+.route-panel-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text-soft);
+}
+
+.route-panel-summary strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.route-reset {
+  align-self: flex-start;
+  padding-left: 0;
+  padding-right: 0;
+  color: var(--text-soft);
+}
+
+.route-reset[disabled],
+.route-reset[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.route-marker {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: white;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  background: #2563eb;
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.3);
+}
+
+.route-marker.route-marker--start {
+  background: #10b981;
+  box-shadow: 0 8px 16px rgba(16, 185, 129, 0.35);
+}
+
+.route-marker.route-marker--end {
+  background: #ef4444;
+  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.35);
 }
 
 .panel-header {

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,8 +1,11 @@
 import { createCameraListItem } from './ui/cameraListItem.js';
 import { populateForm, updateControlDisplay } from './ui/formBinding.js';
+import { setupRoutePanel } from './ui/routePanel.js';
 import { getCameraTypeConfig } from './utils/cameraTypes.js';
 
 export function setupUI({ store, tooltip }) {
+  setupRoutePanel({ store });
+
   const cameraList = document.querySelector('.camera-list');
   const addButton = document.querySelector('.panel-header button');
   const form = document.querySelector('.properties-form');

--- a/src/ui/routePanel.js
+++ b/src/ui/routePanel.js
@@ -1,0 +1,164 @@
+const POINT_LABELS = {
+  start: 'Point A',
+  end: 'Point B',
+};
+
+export function setupRoutePanel({ store }) {
+  const panel = document.querySelector('.route-panel');
+  if (!panel) return;
+
+  const status = panel.querySelector('[data-role="route-status"]');
+  const summary = panel.querySelector('[data-role="route-summary"]');
+  const clearButton = panel.querySelector('[data-action="clear-route"]');
+  const pointButtons = Array.from(panel.querySelectorAll('[data-route-point]'));
+
+  for (const button of pointButtons) {
+    button.addEventListener('click', () => {
+      const point = button.dataset.routePoint;
+      const { route } = store.getState();
+      const nextSelection = route.selection === point ? null : point;
+      store.setRouteSelection(nextSelection);
+    });
+  }
+
+  if (clearButton) {
+    clearButton.addEventListener('click', () => {
+      store.clearRoute();
+    });
+  }
+
+  const render = (state) => {
+    const { route } = state;
+    updateButtons(route);
+    updateStatus(route);
+    updateSummary(route);
+  };
+
+  store.subscribe(render);
+  render(store.getState());
+
+  function updateButtons(route) {
+    for (const button of pointButtons) {
+      const point = button.dataset.routePoint;
+      const isActive = route.selection === point;
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.classList.toggle('is-active', isActive);
+
+      const meta = panel.querySelector(`[data-role="point-${point}-meta"]`);
+      const coords = route[point];
+      button.classList.toggle('is-defined', Boolean(coords));
+      if (meta) {
+        meta.textContent = coords ? formatCoordinates(coords) : 'Cliquez sur la carte';
+      }
+    }
+
+    if (clearButton) {
+      const isDisabled = !route.start && !route.end;
+      clearButton.disabled = isDisabled;
+      clearButton.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+    }
+  }
+
+  function updateStatus(route) {
+    if (!status) return;
+
+    if (route.selection) {
+      status.textContent = `Cliquez sur la carte pour placer ${POINT_LABELS[route.selection]}.`;
+      return;
+    }
+    if (route.isLoading) {
+      status.textContent = 'Calcul de l’itinéraire en cours…';
+      return;
+    }
+    if (route.error) {
+      status.textContent = route.error;
+      return;
+    }
+    if (route.path && route.path.length > 1) {
+      status.textContent = 'Itinéraire calculé selon le trajet le plus court.';
+      return;
+    }
+    if (route.start && !route.end) {
+      status.textContent = 'Sélectionnez Point B pour définir l’arrivée.';
+      return;
+    }
+    if (!route.start && route.end) {
+      status.textContent = 'Sélectionnez Point A pour définir le départ.';
+      return;
+    }
+    if (route.start && route.end) {
+      status.textContent = 'Points définis. Relancez un calcul si nécessaire.';
+      return;
+    }
+
+    status.textContent = 'Sélectionnez un point de départ et d’arrivée.';
+  }
+
+  function updateSummary(route) {
+    if (!summary) return;
+
+    if (route.isLoading) {
+      summary.textContent = 'Recherche du meilleur chemin…';
+      return;
+    }
+
+    if (route.error) {
+      summary.textContent = '—';
+      return;
+    }
+
+    if (route.path && route.path.length > 1) {
+      const parts = [];
+      if (route.distance != null) {
+        parts.push(formatDistance(route.distance));
+      }
+      if (route.duration != null) {
+        parts.push(formatDuration(route.duration));
+      }
+      summary.textContent = parts.length > 0 ? parts.join(' • ') : 'Itinéraire disponible';
+      return;
+    }
+
+    summary.textContent = '—';
+  }
+}
+
+function formatCoordinates({ lat, lon }) {
+  return `${formatNumber(lat)}°, ${formatNumber(lon)}°`;
+}
+
+function formatNumber(value) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return Number(value).toFixed(4);
+}
+
+function formatDistance(meters) {
+  if (!Number.isFinite(meters)) {
+    return 'Distance inconnue';
+  }
+  if (meters >= 1000) {
+    return `${(meters / 1000).toFixed(1)} km`;
+  }
+  return `${Math.round(meters)} m`;
+}
+
+function formatDuration(seconds) {
+  if (!Number.isFinite(seconds)) {
+    return 'Durée inconnue';
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 1) {
+    return 'Moins d’une minute';
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (remainingMinutes === 0) {
+    return `${hours} h`;
+  }
+  return `${hours} h ${remainingMinutes} min`;
+}


### PR DESCRIPTION
## Summary
- add a dedicated itinerary panel above the camera list to pick start and end points
- extend application state and map canvas to fetch and display shortest routes using OSRM
- style the new controls and markers to match the existing interface

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfbc1bed708329af848d0a406dedac