### PR TITLE
Refine the route selection panel styling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -119,66 +119,66 @@ body {
 }
 
 .route-panel {
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.72);
-  backdrop-filter: blur(24px);
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.08);
 }
 
 .route-panel .panel-header {
-  padding: 24px 24px 12px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 18px 20px 8px;
+  border-bottom: none;
   background: transparent;
 }
 
 .route-panel .panel-header h2 {
-  font-size: 1rem;
+  font-size: 0.95rem;
   letter-spacing: 0.01em;
+  font-weight: 600;
 }
 
 .route-panel-body {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 0 24px 24px;
+  gap: 12px;
+  padding: 0 20px 20px;
 }
 
 .route-panel-status {
   margin: 0;
-  font-size: 0.85rem;
-  color: rgba(15, 23, 42, 0.55);
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.5);
   line-height: 1.4;
 }
 
 .route-points {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .route-point-button {
-  display: grid;
-  grid-template-columns: auto 1fr;
+  display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 12px 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid transparent;
   text-align: left;
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .route-point-button:hover {
+  background: rgba(255, 255, 255, 0.8);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
 }
 
 .route-point-button.is-active {
-  border-color: rgba(56, 189, 248, 0.8);
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.22);
+  border-color: rgba(10, 132, 255, 0.4);
+  background: rgba(10, 132, 255, 0.12);
 }
 
 .route-point-button.is-defined .route-point-marker {
@@ -189,16 +189,16 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   font-weight: 600;
   color: white;
   letter-spacing: 0.02em;
   background: linear-gradient(135deg, #2563eb, #60a5fa);
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.3);
-  opacity: 0.75;
+  box-shadow: none;
+  opacity: 0.7;
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
@@ -210,74 +210,69 @@ body {
 
 .route-point-button--start .route-point-marker {
   background: linear-gradient(135deg, #34d399, #10b981);
-  box-shadow: 0 10px 20px rgba(16, 185, 129, 0.28);
 }
 
 .route-point-button--end .route-point-marker {
   background: linear-gradient(135deg, #f97316, #ef4444);
-  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.28);
 }
 
 .route-point-content {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .route-point-title {
   font-weight: 600;
   color: var(--text);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .route-point-meta {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: rgba(15, 23, 42, 0.45);
 }
 
 .route-panel-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(15, 23, 42, 0.06);
   color: rgba(15, 23, 42, 0.55);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 .route-panel-summary strong {
   font-weight: 600;
   color: var(--text);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .route-reset {
-  align-self: stretch;
-  padding: 12px 16px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.75);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  color: rgba(15, 23, 42, 0.55);
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease,
-    border-color 0.2s ease;
+  align-self: flex-start;
+  padding: 6px 0;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-weight: 500;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease;
 }
 
 .route-reset:hover,
 .route-reset:focus-visible {
-  background: rgba(255, 255, 255, 0.95);
-  color: rgba(15, 23, 42, 0.75);
-  border-color: rgba(15, 23, 42, 0.15);
-  transform: translateY(-1px);
+  color: #0060df;
 }
 
 .route-reset[disabled],
 .route-reset[aria-disabled='true'] {
-  cursor: not-allowed;
-  opacity: 0.35;
-  transform: none;
-  background: rgba(255, 255, 255, 0.6);
+  color: rgba(15, 23, 42, 0.3);
+  cursor: default;
 }
 
 .route-marker {


### PR DESCRIPTION
## Summary
- soften the route selection panel background and spacing to reduce its visual weight
- simplify route point buttons and summary layout for a more compact appearance
- restyle the reset action as a lightweight text control to match the streamlined panel

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfc5a4ddd88329bc4079c767d6afe4