### PR TITLE
Add travel mode selector to itinerary panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,36 @@
               <p class="route-panel-status" data-role="route-status" aria-live="polite">
                 Choisissez deux points sur la carte.
               </p>
+              <div
+                class="route-modes"
+                role="group"
+                aria-label="Mode de déplacement"
+              >
+                <button
+                  type="button"
+                  class="route-mode-button"
+                  data-route-mode="walking"
+                  aria-pressed="false"
+                >
+                  À pied
+                </button>
+                <button
+                  type="button"
+                  class="route-mode-button"
+                  data-route-mode="cycling"
+                  aria-pressed="false"
+                >
+                  Vélo
+                </button>
+                <button
+                  type="button"
+                  class="route-mode-button"
+                  data-route-mode="driving"
+                  aria-pressed="false"
+                >
+                  Voiture
+                </button>
+              </div>
               <div class="route-points" role="group" aria-label="Points de l’itinéraire">
                 <button
                   type="button"

--- a/src/map/canvas.js
+++ b/src/map/canvas.js
@@ -191,7 +191,7 @@ export function setupMapCanvas({ store, tooltip }) {
       return;
     }
 
-    const key = getRouteKey(route.start, route.end);
+    const key = getRouteKey(route.start, route.end, route.mode);
 
     if (!Array.isArray(route.path) || route.path.length === 0) {
       if (lastRouteKey === key) {
@@ -213,14 +213,14 @@ export function setupMapCanvas({ store, tooltip }) {
     }
 
     activeRouteKey = key;
-    requestRoute(route.start, route.end, key);
+    requestRoute(route.start, route.end, route.mode, key);
   }
 
-  async function requestRoute(start, end, key) {
+  async function requestRoute(start, end, mode, key) {
     const requestId = ++routeRequestId;
     store.setRouteLoading(true);
     try {
-      const result = await fetchRouteBetween(start, end);
+      const result = await fetchRouteBetween(start, end, mode);
       if (requestId !== routeRequestId) {
         return;
       }
@@ -253,8 +253,11 @@ export function setupMapCanvas({ store, tooltip }) {
     return Boolean(point) && Number.isFinite(point.lat) && Number.isFinite(point.lon);
   }
 
-  function getRouteKey(start, end) {
-    return [start.lat, start.lon, end.lat, end.lon].map(formatNumber).join('|');
+  function getRouteKey(start, end, mode) {
+    const coordsKey = [start.lat, start.lon, end.lat, end.lon]
+      .map(formatNumber)
+      .join('|');
+    return `${coordsKey}|${mode || 'driving'}`;
   }
 
   function ensureCameraLayers(camera, appearance) {

--- a/src/services/routing.js
+++ b/src/services/routing.js
@@ -1,18 +1,32 @@
-const OSRM_BASE_URL = 'https://router.project-osrm.org/route/v1/driving/';
+const OSRM_BASE_URL = 'https://router.project-osrm.org/route/v1/';
+const OSRM_PROFILES = {
+  driving: 'driving',
+  walking: 'walking',
+  cycling: 'cycling',
+};
 
-function buildRouteUrl(start, end) {
+function resolveProfile(mode) {
+  if (typeof mode !== 'string') {
+    return OSRM_PROFILES.driving;
+  }
+  const normalized = mode.toLowerCase();
+  return OSRM_PROFILES[normalized] || OSRM_PROFILES.driving;
+}
+
+function buildRouteUrl(start, end, mode) {
   const startCoords = `${start.lon},${start.lat}`;
   const endCoords = `${end.lon},${end.lat}`;
   const params = new URLSearchParams({ overview: 'full', geometries: 'geojson' });
-  return `${OSRM_BASE_URL}${startCoords};${endCoords}?${params.toString()}`;
+  const profile = resolveProfile(mode);
+  return `${OSRM_BASE_URL}${profile}/${startCoords};${endCoords}?${params.toString()}`;
 }
 
-export async function fetchRouteBetween(start, end) {
+export async function fetchRouteBetween(start, end, mode = 'driving') {
   if (!start || !end) {
     throw new Error('Points de départ et d’arrivée requis.');
   }
 
-  const url = buildRouteUrl(start, end);
+  const url = buildRouteUrl(start, end, mode);
   const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
   if (!response.ok) {
     throw new Error('Service de calcul d’itinéraire indisponible.');

--- a/src/state.js
+++ b/src/state.js
@@ -20,6 +20,7 @@ const DEFAULT_ROUTE_STATE = {
   selection: null,
   isLoading: false,
   error: null,
+  mode: 'driving',
 };
 
 export function createStateStore() {
@@ -135,6 +136,23 @@ export function createStateStore() {
       state = { ...state, route: nextRoute };
       notify();
     },
+    setRouteMode(mode) {
+      const allowed = new Set(['driving', 'walking', 'cycling']);
+      const normalized = allowed.has(mode) ? mode : DEFAULT_ROUTE_STATE.mode;
+      const nextRoute = {
+        ...state.route,
+        mode: normalized,
+      };
+      if (nextRoute.mode !== state.route.mode) {
+        nextRoute.path = null;
+        nextRoute.distance = null;
+        nextRoute.duration = null;
+        nextRoute.error = null;
+        nextRoute.isLoading = false;
+      }
+      state = { ...state, route: nextRoute };
+      notify();
+    },
     setRouteLoading(isLoading) {
       state = {
         ...state,
@@ -183,7 +201,7 @@ export function createStateStore() {
     clearRoute() {
       state = {
         ...state,
-        route: { ...DEFAULT_ROUTE_STATE },
+        route: { ...DEFAULT_ROUTE_STATE, mode: state.route.mode || DEFAULT_ROUTE_STATE.mode },
       };
       notify();
     },

--- a/src/styles.css
+++ b/src/styles.css
@@ -152,6 +152,35 @@ body {
   line-height: 1.4;
 }
 
+.route-modes {
+  display: flex;
+  gap: 8px;
+}
+
+.route-mode-button {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.55);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.7);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.route-mode-button:hover {
+  background: rgba(255, 255, 255, 0.9);
+  transform: translateY(-1px);
+}
+
+.route-mode-button.is-active {
+  border-color: rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
 .route-points {
   display: flex;
   flex-direction: column;

--- a/src/ui/routePanel.js
+++ b/src/ui/routePanel.js
@@ -11,6 +11,7 @@ export function setupRoutePanel({ store }) {
   const summary = panel.querySelector('[data-role="route-summary"]');
   const clearButton = panel.querySelector('[data-action="clear-route"]');
   const pointButtons = Array.from(panel.querySelectorAll('[data-route-point]'));
+  const modeButtons = Array.from(panel.querySelectorAll('[data-route-mode]'));
 
   for (const button of pointButtons) {
     button.addEventListener('click', () => {
@@ -18,6 +19,13 @@ export function setupRoutePanel({ store }) {
       const { route } = store.getState();
       const nextSelection = route.selection === point ? null : point;
       store.setRouteSelection(nextSelection);
+    });
+  }
+
+  for (const button of modeButtons) {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.routeMode;
+      store.setRouteMode(mode);
     });
   }
 
@@ -30,6 +38,7 @@ export function setupRoutePanel({ store }) {
   const render = (state) => {
     const { route } = state;
     updateButtons(route);
+    updateModes(route);
     updateStatus(route);
     updateSummary(route);
   };
@@ -120,6 +129,18 @@ export function setupRoutePanel({ store }) {
     }
 
     summary.textContent = '—';
+  }
+
+  function updateModes(route) {
+    if (modeButtons.length === 0) return;
+
+    const activeMode = route?.mode || 'driving';
+    for (const button of modeButtons) {
+      const mode = button.dataset.routeMode;
+      const isActive = mode === activeMode;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add walking, cycling, and driving mode buttons to the itinerary panel UI
- store the selected travel mode in application state and requery OSRM with the appropriate profile
- update route fetching logic and styling so routes refresh when the mode changes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfcac338e08329998c7583bbd43600