### PR TITLE
Adjust camera panel layout to enable scrolling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -343,6 +343,13 @@ body {
   font-weight: 600;
 }
 
+.panel-left {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .panel-left .panel-body {
   display: flex;
   flex-direction: column;
@@ -354,11 +361,11 @@ body {
 .camera-scroll-area {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .camera-scroll-area .camera-list {
-  height: 100%;
   overflow-y: auto;
 }
 
@@ -387,7 +394,6 @@ body {
   list-style: none;
   margin: 0;
   padding: 0 12px 16px;
-  height: 100%;
 }
 
 .camera-list li {


### PR DESCRIPTION
## Summary
- make the left camera panel fill the sidebar column height
- allow the camera list area to scroll vertically when content exceeds the view

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dfce7368608329b830c91ef78f96d4