### PR TITLE
Fix camera panel layout overflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -41,7 +41,7 @@ body {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   width: min(1400px, 100%);
-  min-height: 100vh;
+  height: 100vh;
   background: var(--bg);
   padding: 24px clamp(12px, 3vw, 32px);
   gap: 20px;


### PR DESCRIPTION
## Summary
- keep the overall application shell locked to the viewport height
- prevent the map and properties panels from being pushed down when many cameras are added

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfd846f8148329bc142a00b49f9d65