### PR TITLE
Map walking and cycling modes to OSRM foot and bike profiles

### DIFF
--- a/src/services/routing.js
+++ b/src/services/routing.js
@@ -1,8 +1,8 @@
 const OSRM_BASE_URL = 'https://router.project-osrm.org/route/v1/';
 const OSRM_PROFILES = {
   driving: 'driving',
-  walking: 'walking',
-  cycling: 'cycling',
+  walking: 'foot',
+  cycling: 'bike',
 };
 
 function resolveProfile(mode) {


### PR DESCRIPTION
## Summary
- map the walking mode to the OSRM `foot` profile and the cycling mode to the `bike` profile while leaving driving unchanged

## Testing
- Manual Playwright check: set start/end points on the map and switched between driving, walking, and cycling modes to confirm the OSRM requests use the expected profiles

------
https://chatgpt.com/codex/tasks/task_e_68dfe3f39a60832989509a457059a6b4