### PR TITLE
Replace header help button with import action

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,9 @@
             <h1>Sentinel Vision</h1>
             <p>Cartographie CCTV</p>
           </div>
+        </div>
         <nav class="header-actions" aria-label="Actions principales">
-          <button class="ghost" type="button">Aide</button>
+          <button class="ghost" type="button">Importer</button>
           <button class="ghost" type="button">Exporter</button>
         </nav>
       </header>


### PR DESCRIPTION
## Summary
- replace the header help button with an Import action alongside Exporter
- close the brand block container to keep the header layout structure intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe5623aa88329b54edbc844e4e6ce