### PR TITLE
Adjust responsive layout width for default zoom

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -40,10 +40,10 @@ body {
 .app-shell {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
-  width: min(1400px, 100%);
+  width: min(1200px, 100%);
   height: 100vh;
   background: var(--bg);
-  padding: 24px clamp(12px, 3vw, 32px);
+  padding: 20px clamp(12px, 2.5vw, 28px);
   gap: 20px;
   overflow: auto;
 }
@@ -91,7 +91,7 @@ body {
 
 .app-main {
   display: grid;
-  grid-template-columns: 280px 1fr 320px;
+  grid-template-columns: 260px minmax(0, 1fr) 300px;
   gap: 20px;
   height: 100%;
   min-height: 0;
@@ -866,8 +866,12 @@ button.primary:hover {
 }
 
 @media (max-width: 1280px) {
+  .app-shell {
+    width: min(100%, 960px);
+  }
+
   .app-main {
-    grid-template-columns: 260px 1fr 300px;
+    grid-template-columns: 240px minmax(0, 1fr) 280px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce the maximum shell width and default column sizes so the interface fits at 100% browser zoom
- update the medium breakpoint to keep panels readable on smaller displays

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68dfe8f81a108329bf8fb155ec61b87b