### PR TITLE
Improve responsive layout to enlarge map viewport

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -32,20 +32,18 @@ body {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
+  overflow: hidden;
 }
 
 .app-shell {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
-  width: min(1200px, 100%);
+  width: 100%;
   height: 100vh;
   background: var(--bg);
-  padding: 20px clamp(12px, 2.5vw, 28px);
-  gap: 20px;
-  overflow: auto;
+  padding: clamp(16px, 2vw, 32px) clamp(16px, 2.5vw, 32px);
+  gap: clamp(16px, 2vw, 28px);
+  overflow: hidden;
 }
 
 .app-header {
@@ -91,10 +89,14 @@ body {
 
 .app-main {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr) 300px;
-  gap: 20px;
+  grid-template-columns:
+    clamp(180px, 12vw, 220px)
+    minmax(0, 1fr)
+    clamp(200px, 14vw, 250px);
+  gap: clamp(16px, 2vw, 28px);
   height: 100%;
   min-height: 0;
+  align-items: stretch;
 }
 
 .sidebar-column {
@@ -428,6 +430,7 @@ body {
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow);
   overflow: hidden;
+  min-height: 0;
 }
 
 .map-canvas {
@@ -866,12 +869,9 @@ button.primary:hover {
 }
 
 @media (max-width: 1280px) {
-  .app-shell {
-    width: min(100%, 960px);
-  }
-
   .app-main {
-    grid-template-columns: 240px minmax(0, 1fr) 280px;
+    grid-template-columns: clamp(200px, 20vw, 240px) minmax(0, 1fr)
+      clamp(220px, 24vw, 260px);
   }
 }
 
@@ -881,7 +881,7 @@ button.primary:hover {
   }
 
   .app-main {
-    grid-template-columns: 240px 1fr;
+    grid-template-columns: clamp(200px, 32vw, 240px) minmax(0, 1fr);
     grid-template-areas:
       'panel-left map'
       'panel-right map';
@@ -904,6 +904,7 @@ button.primary:hover {
   .app-main {
     display: flex;
     flex-direction: column;
+    gap: clamp(16px, 3vw, 24px);
   }
 
   .panel,
@@ -918,6 +919,6 @@ button.primary:hover {
 
   .map-stage {
     order: 1;
-    min-height: 360px;
+    min-height: clamp(320px, 55vh, 520px);
   }
 }


### PR DESCRIPTION
## Summary
- expand the application shell to occupy the full viewport without outer scrolling
- resize the map and side panel grid so the map dominates horizontal space on wide screens
- tune responsive breakpoints and spacing for better tablet and mobile layouts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dff22c53bc8329987a081aefa785e2