### PR TITLE
Normalize route mode handling

### DIFF
--- a/src/services/routing.js
+++ b/src/services/routing.js
@@ -15,7 +15,7 @@ const OSRM_PROFILE_ALIASES = {
   vélo: OSRM_PROFILES.cycling,
 };
 
-function resolveProfile(mode) {
+export function resolveProfile(mode) {
   if (typeof mode !== 'string') {
     return OSRM_PROFILES.driving;
   }

--- a/src/state.js
+++ b/src/state.js
@@ -1,3 +1,4 @@
+import { resolveProfile } from './services/routing.js';
 import { nanoid } from './utils/nanoid.js';
 import { DEFAULT_CAMERA_TYPE, getCameraTypeConfig } from './utils/cameraTypes.js';
 
@@ -137,8 +138,8 @@ export function createStateStore() {
       notify();
     },
     setRouteMode(mode) {
-      const allowed = new Set(['driving', 'walking', 'cycling']);
-      const normalized = allowed.has(mode) ? mode : DEFAULT_ROUTE_STATE.mode;
+      const cleanedMode = typeof mode === 'string' ? mode.trim() : mode;
+      const normalized = resolveProfile(cleanedMode);
       const nextRoute = {
         ...state.route,
         mode: normalized,

--- a/src/ui/routePanel.js
+++ b/src/ui/routePanel.js
@@ -1,3 +1,5 @@
+import { resolveProfile } from '../services/routing.js';
+
 const POINT_LABELS = {
   start: 'le départ',
   end: 'l’arrivée',
@@ -147,10 +149,13 @@ export function setupRoutePanel({ store }) {
   function updateModes(route) {
     if (modeButtons.length === 0) return;
 
-    const activeMode = route?.mode || 'driving';
+    const activeMode = resolveProfile(route?.mode);
     for (const button of modeButtons) {
-      const mode = button.dataset.routeMode;
-      const isActive = mode === activeMode;
+      const mode = typeof button.dataset.routeMode === 'string'
+        ? button.dataset.routeMode.trim()
+        : button.dataset.routeMode;
+      const resolvedMode = resolveProfile(mode);
+      const isActive = resolvedMode === activeMode;
       button.classList.toggle('is-active', isActive);
       button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     }


### PR DESCRIPTION
## Summary
- export the shared `resolveProfile` helper to normalize routing profiles
- sanitize `setRouteMode` inputs via the resolver before updating state
- update the route panel to activate buttons based on normalized modes

## Testing
- node --input-type=module <<'NODE'
import { createStateStore } from './src/state.js';

const store = createStateStore();
store.setRouteMode('marche');
console.log('marche ->', store.getState().route.mode);
store.setRouteMode('bike');
console.log('bike ->', store.getState().route.mode);
NODE


------
https://chatgpt.com/codex/tasks/task_e_68dff4ac06b48329ba0efe28ed7a394f