### PR TITLE
Adjust layout to emphasize map on large screens

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -37,12 +37,12 @@ body {
 
 .app-shell {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr);
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   background: var(--bg);
-  padding: clamp(16px, 2vw, 32px) clamp(16px, 2.5vw, 32px);
-  gap: clamp(16px, 2vw, 28px);
+  padding: clamp(16px, 1.8vw, 28px) clamp(16px, 2.2vw, 32px);
+  gap: clamp(16px, 1.8vw, 28px);
   overflow: hidden;
 }
 
@@ -90,10 +90,10 @@ body {
 .app-main {
   display: grid;
   grid-template-columns:
-    clamp(180px, 12vw, 220px)
+    minmax(200px, 13vw)
     minmax(0, 1fr)
-    clamp(200px, 14vw, 250px);
-  gap: clamp(16px, 2vw, 28px);
+    minmax(240px, 15vw);
+  gap: clamp(16px, 2vw, 32px);
   height: 100%;
   min-height: 0;
   align-items: stretch;
@@ -102,8 +102,9 @@ body {
 .sidebar-column {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: clamp(16px, 1.5vw, 22px);
   min-height: 0;
+  max-width: 100%;
 }
 
 .sidebar-column .panel {
@@ -117,6 +118,7 @@ body {
   flex-direction: column;
   box-shadow: var(--shadow);
   min-height: 0;
+  max-height: 100%;
   overflow: hidden;
 }
 
@@ -431,6 +433,7 @@ body {
   box-shadow: var(--shadow);
   overflow: hidden;
   min-height: 0;
+  min-width: 0;
 }
 
 .map-canvas {
@@ -440,6 +443,7 @@ body {
   border-radius: var(--radius-xl);
   overflow: hidden;
   min-height: 0;
+  min-width: 0;
 }
 
 #map-view {
@@ -872,6 +876,25 @@ button.primary:hover {
   .app-main {
     grid-template-columns: clamp(200px, 20vw, 240px) minmax(0, 1fr)
       clamp(220px, 24vw, 260px);
+  }
+}
+
+@media (min-width: 1600px) {
+  .app-main {
+    grid-template-columns: minmax(220px, 12vw) minmax(0, 1fr)
+      minmax(260px, 13vw);
+  }
+}
+
+@media (min-width: 1920px) {
+  .app-main {
+    grid-template-columns: minmax(240px, 11vw) minmax(0, 1fr)
+      minmax(280px, 12vw);
+  }
+
+  .app-shell {
+    padding-inline: clamp(24px, 3vw, 48px);
+    padding-block: clamp(20px, 2.4vw, 40px);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the map column and adjust responsive breakpoints so the canvas occupies the majority of wide viewports
- tighten sidebar spacing and panel sizing to keep controls visible yet compact
- tweak shell padding rules to preserve a full-height layout without vertical scrolling

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dff5459c5c8329bfd7599b04b653a4