### PR TITLE
Fix OSRM profile mapping for walking and cycling

### DIFF
--- a/src/services/routing.js
+++ b/src/services/routing.js
@@ -23,12 +23,19 @@ export function resolveProfile(mode) {
   return OSRM_PROFILES[normalized] || OSRM_PROFILE_ALIASES[normalized] || OSRM_PROFILES.driving;
 }
 
+const OSRM_API_PROFILE_MAP = {
+  [OSRM_PROFILES.driving]: 'driving',
+  [OSRM_PROFILES.walking]: 'foot',
+  [OSRM_PROFILES.cycling]: 'bike',
+};
+
 function buildRouteUrl(start, end, mode) {
   const startCoords = `${start.lon},${start.lat}`;
   const endCoords = `${end.lon},${end.lat}`;
   const params = new URLSearchParams({ overview: 'full', geometries: 'geojson' });
   const profile = resolveProfile(mode);
-  return `${OSRM_BASE_URL}${profile}/${startCoords};${endCoords}?${params.toString()}`;
+  const profileSlug = OSRM_API_PROFILE_MAP[profile] ?? OSRM_API_PROFILE_MAP[OSRM_PROFILES.driving];
+  return `${OSRM_BASE_URL}${profileSlug}/${startCoords};${endCoords}?${params.toString()}`;
 }
 
 export async function fetchRouteBetween(start, end, mode = 'driving') {


### PR DESCRIPTION
## Summary
- add OSRM API profile mapping to translate UI modes to router slugs
- ensure route URLs use the API mapping with a driving fallback

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dff77ad2a8832991ab86a7ed20617d