### PR TITLE
Fix layout height and map stage flexibility

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -39,7 +39,7 @@ body {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   background: var(--bg);
   padding: clamp(16px, 1.8vw, 28px) clamp(16px, 2.2vw, 32px);
   gap: clamp(16px, 1.8vw, 28px);
@@ -942,6 +942,7 @@ button.primary:hover {
 
   .map-stage {
     order: 1;
-    min-height: clamp(320px, 55vh, 520px);
+    min-height: 0;
+    flex: 1 1 0;
   }
 }


### PR DESCRIPTION
## Summary
- force the app grid to match the viewport height so panels cannot expand the layout vertically
- let the map stage shrink on narrow layouts by clearing its minimum height and allowing it to flex

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff83063b48329b7d1625f4fd8d4d3